### PR TITLE
Remove use of /proc/self for macOS compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "dunce",
  "handlebars",
  "handlebars_misc_helpers",
+ "libc",
  "log",
  "maplit",
  "meval",
@@ -807,9 +808,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "linked-hash-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ mockall = "0.9.*"
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.*"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.94"

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -266,10 +266,7 @@ impl RealFilesystem {
     fn is_owned_by_user(&self, path: &Path) -> Result<bool> {
         use std::os::unix::fs::MetadataExt;
         let file_uid = path.metadata().context("get file metadata")?.uid();
-        let process_uid = std::path::PathBuf::from("/proc/self")
-            .metadata()
-            .context("get metadata of /proc/self")?
-            .uid();
+        let process_uid = unsafe { libc::geteuid() };
         Ok(file_uid == process_uid)
     }
 }


### PR DESCRIPTION
Closes #62 

## Description

Fixes a bug on macOS where running `dotter deploy` twice would error. The error specifically occurred when attempting to obtain the effective UID of the process.

## Implementation

Use [`libc::geteuid()`](https://docs.rs/libc/0.2.12/libc/fn.geteuid.html) to get the effective UID instead of looking at the metadata for `/proc/self` which does not exist on macOS.