### PR TITLE
Merge variable tables instead of bailing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -199,6 +199,19 @@ fn recursive_extend_map(
     }
 }
 
+/// Merge two TOML tables
+fn merge_tables(a: &mut toml::Value, b: &toml::Value) {
+    if let (toml::Value::Table(a), toml::Value::Table(b)) = (a, b) {
+        for (k, v) in b {
+            merge_tables(
+                a.entry(k.clone())
+                    .or_insert_with(|| toml::Value::Table(Default::default())),
+                v,
+            );
+        }
+    }
+}
+
 #[allow(clippy::map_entry)]
 fn merge_configuration_files(
     mut global: GlobalConfig,
@@ -288,7 +301,17 @@ fn merge_configuration_files(
 
             for (variable_name, variable_value) in package.variables {
                 if first_package.variables.contains_key(&variable_name) {
-                    anyhow::bail!("variable {:?} already encountered", variable_name);
+                    // Panic safety: Already checked via `contains_key` above
+                    let mut first_value = first_package.variables.get_mut(&variable_name).unwrap();
+                    match (&mut first_value, &variable_value) {
+                        (toml::Value::Table(_a), toml::Value::Table(_b)) => {
+                            info!("Merging {:?} tables", variable_name);
+                            merge_tables(&mut first_value, &variable_value);
+                        }
+                        _ => {
+                            anyhow::bail!("variable {:?} already encountered", variable_name);
+                        }
+                    }
                 } else {
                     first_package
                         .variables


### PR DESCRIPTION
This allows to have nested tables for variables.

I'm using it in my Neovim config to do some package-specific configuration if (and only if) a package is enabled:

```toml
# global.toml
[rustdev.variables]
neovim.subpackages.rustdev = true
[luadev.variables]
neovim.subpackages.luadev = true
```

With this, I can loop over the `neovim.subpackages` variable and do something for all *enabled* packages only—like run some package-specific code:

```lua
-- subpackages.lua
local subpackages = {
  {{#each neovim.subpackages}}
  '{{@key}}',
  {{/each}}
}
for _, subpackage in ipairs(subpackages) do
  require(subpackage)
```

Now, if I decide to disable the `luadev` package, I won't have to change `subpackages.lua` in any way—since the variable `neovim.subpackages.luadev` doesn't exist anymore, it won't be in the `subpackages` list.

I'm pretty sure this would enable other functionality as well, considering the power of the handlebars templating facility.
