### PR TITLE
Use <hostname>.toml if local.toml is not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "dunce",
  "handlebars",
  "handlebars_misc_helpers",
+ "hostname",
  "libc",
  "log",
  "maplit",
@@ -564,6 +565,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +704,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = "2.*"
 crossterm = "0.18.*"
 diff = "0.1.*"
 handlebars = { version = "3.*", features = ["script_helper"] }
+hostname = "0.3.*"
 log = "0.4.*"
 maplit = "1.*"
 meval = "0.2.*"


### PR DESCRIPTION
Not fully tested nor optimized, but it seems to work.
Let me know if you want me to restructure anything (like the location of the `file_exists()` function)

Ideally we would only check the hostname if `local.toml` isn't found, but I ran into lifetime errors since the hostname variable would expire before loading the config, unless I duplicated the code for loading the file (one if local.toml was found, and another if it wasn't).