### PR TITLE
Add copy target type

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -4,15 +4,17 @@ use anyhow::{Context, Result};
 use crossterm::style::Colorize;
 use handlebars::Handlebars;
 
-use crate::config::{SymbolicTarget, TemplateTarget, Variables};
+use crate::config::{CopyTarget, SymbolicTarget, TemplateTarget, Variables};
 use crate::difference;
 use crate::filesystem::{Filesystem, SymlinkComparison, TemplateComparison};
 
 #[cfg_attr(test, mockall::automock)]
 pub trait ActionRunner {
     fn delete_symlink(&mut self, source: &Path, target: &Path) -> Result<bool>;
+    fn delete_copy(&mut self, source: &Path, target: &Path) -> Result<bool>;
     fn delete_template(&mut self, source: &Path, cache: &Path, target: &Path) -> Result<bool>;
     fn create_symlink(&mut self, source: &Path, target: &SymbolicTarget) -> Result<bool>;
+    fn create_copy(&mut self, source: &Path, target: &CopyTarget) -> Result<bool>;
     fn create_template(
         &mut self,
         source: &Path,
@@ -20,6 +22,7 @@ pub trait ActionRunner {
         target: &TemplateTarget,
     ) -> Result<bool>;
     fn update_symlink(&mut self, source: &Path, target: &SymbolicTarget) -> Result<bool>;
+    fn update_copy(&mut self, source: &Path, target: &CopyTarget) -> Result<bool>;
     fn update_template(
         &mut self,
         source: &Path,
@@ -58,11 +61,17 @@ impl<'a> ActionRunner for RealActionRunner<'a> {
     fn delete_symlink(&mut self, source: &Path, target: &Path) -> Result<bool> {
         delete_symlink(source, target, self.fs, self.force)
     }
+    fn delete_copy(&mut self, source: &Path, target: &Path) -> Result<bool> {
+        delete_copy(source, target, self.fs, self.force)
+    }
     fn delete_template(&mut self, source: &Path, cache: &Path, target: &Path) -> Result<bool> {
         delete_template(source, cache, target, self.fs, self.force)
     }
     fn create_symlink(&mut self, source: &Path, target: &SymbolicTarget) -> Result<bool> {
         create_symlink(source, target, self.fs, self.force)
+    }
+    fn create_copy(&mut self, source: &Path, target: &CopyTarget) -> Result<bool> {
+        create_copy(source, target, self.fs, self.force)
     }
     fn create_template(
         &mut self,
@@ -82,6 +91,9 @@ impl<'a> ActionRunner for RealActionRunner<'a> {
     }
     fn update_symlink(&mut self, source: &Path, target: &SymbolicTarget) -> Result<bool> {
         update_symlink(source, target, self.fs, self.force)
+    }
+    fn update_copy(&mut self, source: &Path, target: &CopyTarget) -> Result<bool> {
+        update_copy(source, target, self.fs, self.force)
     }
     fn update_template(
         &mut self,
@@ -156,6 +168,17 @@ fn perform_symlink_target_deletion(fs: &mut dyn Filesystem, target: &Path) -> Re
     fs.delete_parents(target, false)
         .context("delete parents of symlink")?;
     Ok(())
+}
+
+/// Returns true if copy should be deleted from cache
+pub fn delete_copy(
+    source: &Path,
+    target: &Path,
+    fs: &mut dyn Filesystem,
+    force: bool,
+) -> Result<bool> {
+    warn!("Delete copy not yet implemented");
+    Ok(false)
 }
 
 /// Returns true if template should be deleted from cache
@@ -297,6 +320,17 @@ pub fn create_symlink(
             Ok(false)
         }
     }
+}
+
+/// Returns true if copy should be added to cache
+pub fn create_copy(
+    source: &Path,
+    target: &CopyTarget,
+    fs: &mut dyn Filesystem,
+    force: bool,
+) -> Result<bool> {
+    warn!("Create copy not yet implemented");
+    Ok(false)
 }
 
 /// Returns true if the template should be added to cache
@@ -454,6 +488,17 @@ pub fn update_symlink(
             Ok(true)
         }
     }
+}
+
+/// Returns true if the symlink wasn't skipped
+pub fn update_copy(
+    source: &Path,
+    target: &CopyTarget,
+    fs: &mut dyn Filesystem,
+    force: bool,
+) -> Result<bool> {
+    warn!("Update copy not yet implemented");
+    Ok(false)
 }
 
 /// Returns true if the template was not skipped

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -197,7 +197,7 @@ pub fn delete_copy(
             );
             Ok(true)
         }
-        CopyComparison::Changed | CopyComparison::TargetNotRegularFileOrDirectory if force => {
+        CopyComparison::Changed | CopyComparison::TargetNotRegularFile if force => {
             warn!(
                 "Deleting copy {:?} -> {:?} but {}. Forcing.",
                 source, target, comparison
@@ -205,7 +205,7 @@ pub fn delete_copy(
             perform_copy_target_deletion(fs, target).context("perform copy target deletion")?;
             Ok(true)
         }
-        CopyComparison::Changed | CopyComparison::TargetNotRegularFileOrDirectory => {
+        CopyComparison::Changed | CopyComparison::TargetNotRegularFile => {
             error!(
                 "Deleting {:?} -> {:?} but {}. Skipping.",
                 source, target, comparison
@@ -403,7 +403,7 @@ pub fn create_copy(
             );
             Ok(false)
         }
-        CopyComparison::Changed | CopyComparison::TargetNotRegularFileOrDirectory if force => {
+        CopyComparison::Changed | CopyComparison::TargetNotRegularFile if force => {
             warn!(
                 "Creating copy {:?} -> {:?} but {}. Forcing.",
                 source, target.target, comparison
@@ -414,7 +414,7 @@ pub fn create_copy(
                 .context("create target copy")?;
             Ok(true)
         }
-        CopyComparison::Changed | CopyComparison::TargetNotRegularFileOrDirectory => {
+        CopyComparison::Changed | CopyComparison::TargetNotRegularFile => {
             error!(
                 "Creating copy {:?} -> {:?} but {}. Skipping.",
                 source, target.target, comparison
@@ -609,7 +609,7 @@ pub fn update_copy(
             );
             Ok(false)
         }
-        CopyComparison::Changed | CopyComparison::TargetNotRegularFileOrDirectory if force => {
+        CopyComparison::Changed | CopyComparison::TargetNotRegularFile if force => {
             warn!(
                 "Updating copy {:?} -> {:?} but {}. Forcing.",
                 source, target.target, comparison
@@ -620,7 +620,7 @@ pub fn update_copy(
                 .context("create target copy")?;
             Ok(true)
         }
-        CopyComparison::Changed | CopyComparison::TargetNotRegularFileOrDirectory => {
+        CopyComparison::Changed | CopyComparison::TargetNotRegularFile => {
             error!(
                 "Updating copy {:?} -> {:?} but {}. Skipping.",
                 source, target.target, comparison

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -742,13 +742,16 @@ pub(crate) fn perform_template_deploy(
     handlebars: &Handlebars<'_>,
     variables: &Variables,
 ) -> Result<()> {
-    let file_contents = fs
+    let original_file_contents = fs
         .read_to_string(&source)
         .context("read template source file")?;
-    let file_contents = target.apply_actions(file_contents);
+    let file_contents = target.apply_actions(original_file_contents.clone());
     let rendered = handlebars
         .render_template(&file_contents, variables)
         .context("render template")?;
+    if original_file_contents == rendered {
+        warn!("File {:?} is specified as 'template' but is not a templated file. Consider using 'copy' instead.", source);
+    }
 
     // Cache
     fs.create_dir_all(&cache.parent().context("get parent of cache file")?, &None)

--- a/src/config.rs
+++ b/src/config.rs
@@ -447,14 +447,12 @@ impl<T: Into<PathBuf>> From<T> for TemplateTarget {
     }
 }
 
-impl SymbolicTarget {
-    pub fn into_template(self) -> TemplateTarget {
-        TemplateTarget {
-            target: self.target,
-            owner: self.owner,
-            condition: self.condition,
-            prepend: None,
-            append: None,
+impl From<SymbolicTarget> for CopyTarget {
+    fn from(st: SymbolicTarget) -> Self {
+        CopyTarget {
+            target: st.target,
+            owner: st.owner,
+            condition: st.condition,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,7 @@ pub fn load_configuration(
 #[serde(deny_unknown_fields)]
 pub struct Cache {
     pub symlinks: BTreeMap<PathBuf, PathBuf>,
+    pub copies: BTreeMap<PathBuf, PathBuf>,
     pub templates: BTreeMap<PathBuf, PathBuf>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,7 +236,7 @@ fn merge_configuration_files(
     // Patch each package with included.toml's
     for included_path in &local.includes {
         || -> Result<()> {
-            let mut included: IncludedConfig = filesystem::load_file(&included_path)
+            let mut included: IncludedConfig = filesystem::load_file(included_path)
                 .and_then(|c| c.ok_or_else(|| anyhow::anyhow!("file not found")))
                 .context("load file")?;
 
@@ -381,7 +381,7 @@ impl<'de> Deserialize<'de> for FileTarget {
 impl FileTarget {
     pub fn path(&self) -> &Path {
         match self {
-            FileTarget::Automatic(path) => &path,
+            FileTarget::Automatic(path) => path,
             FileTarget::Symbolic(SymbolicTarget { target, .. })
             | FileTarget::Copy(CopyTarget { target, .. })
             | FileTarget::ComplexTemplate(TemplateTarget { target, .. }) => &target,
@@ -584,17 +584,14 @@ mod tests {
             .file,
             FileTarget::ComplexTemplate(PathBuf::from("~/.QuarticCat").into()),
         );
-        assert_eq!(
-            parse(
-                r#"
+        assert!(parse(
+            r#"
                     [file]
                     target = '~/.QuarticCat'
                     type = 'symbolic'
                     append = 'whatever'
                 "#,
-            )
-            .is_err(),
-            true
-        );
+        )
+        .is_err());
     }
 }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -138,7 +138,7 @@ Proceeding by copying instead of symlinking."
         &desired_copies,
         &desired_templates,
         &mut cache,
-        &opt,
+        opt,
     );
 
     // === Post-deploy ===
@@ -314,7 +314,7 @@ fn run_deploy<A: ActionRunner>(
         existing_symlinks.difference(&desired_symlinks.keys().cloned().collect())
     {
         execute_action(
-            runner.delete_symlink(&source, &target),
+            runner.delete_symlink(source, target),
             || resulting_cache.symlinks.remove(source),
             || format!("delete symlink {:?} -> {:?}", source, target),
             &mut suggest_force,
@@ -324,7 +324,7 @@ fn run_deploy<A: ActionRunner>(
 
     for (source, target) in existing_copies.difference(&desired_copies.keys().cloned().collect()) {
         execute_action(
-            runner.delete_copy(source, &target),
+            runner.delete_copy(source, target),
             || resulting_cache.copies.remove(source),
             || format!("delete copy {:?} -> {:?}", source, target),
             &mut suggest_force,
@@ -336,7 +336,7 @@ fn run_deploy<A: ActionRunner>(
         existing_templates.difference(&desired_templates.keys().cloned().collect())
     {
         execute_action(
-            runner.delete_template(&source, &opt.cache_directory.join(&source), &target),
+            runner.delete_template(source, &opt.cache_directory.join(&source), target),
             || resulting_cache.templates.remove(source),
             || format!("delete template {:?} -> {:?}", source, target),
             &mut suggest_force,
@@ -354,7 +354,7 @@ fn run_deploy<A: ActionRunner>(
             .get(&(source.into(), target_path.into()))
             .unwrap();
         execute_action(
-            runner.create_symlink(&source, &target),
+            runner.create_symlink(source, target),
             || {
                 resulting_cache
                     .symlinks
@@ -376,7 +376,7 @@ fn run_deploy<A: ActionRunner>(
             .get(&(source.into(), target_path.into()))
             .unwrap();
         execute_action(
-            runner.create_copy(&source, &target),
+            runner.create_copy(source, target),
             || {
                 resulting_cache
                     .copies
@@ -398,7 +398,7 @@ fn run_deploy<A: ActionRunner>(
             .get(&(source.into(), target_path.into()))
             .unwrap();
         execute_action(
-            runner.create_template(&source, &opt.cache_directory.join(&source), &target),
+            runner.create_template(source, &opt.cache_directory.join(&source), target),
             || {
                 resulting_cache
                     .templates
@@ -417,7 +417,7 @@ fn run_deploy<A: ActionRunner>(
             .get(&(source.into(), target_path.into()))
             .unwrap();
         execute_action(
-            runner.update_symlink(&source, &target),
+            runner.update_symlink(source, target),
             || (),
             || format!("update symlink {:?} -> {:?}", source, target_path),
             &mut suggest_force,
@@ -432,7 +432,7 @@ fn run_deploy<A: ActionRunner>(
             .get(&(source.into(), target_path.into()))
             .unwrap();
         execute_action(
-            runner.update_copy(&source, &target),
+            runner.update_copy(source, target),
             || (),
             || format!("update copy {:?} -> {:?}", source, target_path),
             &mut suggest_force,
@@ -447,7 +447,7 @@ fn run_deploy<A: ActionRunner>(
             .get(&(source.into(), target_path.into()))
             .unwrap();
         execute_action(
-            runner.update_template(&source, &opt.cache_directory.join(&source), &target),
+            runner.update_template(source, &opt.cache_directory.join(&source), target),
             || (),
             || format!("update template {:?} -> {:?}", source, target_path),
             &mut suggest_force,
@@ -555,8 +555,8 @@ mod test {
             },
         );
 
-        assert_eq!(suggest_force, false);
-        assert_eq!(error_occurred, false);
+        assert!(!suggest_force);
+        assert!(!error_occurred);
 
         assert!(cache.symlinks.contains_key(&PathBuf::from("a_in")));
         assert!(cache.copies.contains_key(&PathBuf::from("b_in")));
@@ -625,8 +625,8 @@ mod test {
             },
         );
 
-        assert_eq!(suggest_force, true);
-        assert_eq!(error_occurred, true);
+        assert!(suggest_force);
+        assert!(error_occurred);
 
         assert_eq!(cache.symlinks.len(), 0);
         assert_eq!(cache.templates.len(), 0);
@@ -680,8 +680,8 @@ mod test {
             },
         );
 
-        assert_eq!(suggest_force, false);
-        assert_eq!(error_occurred, false);
+        assert!(!suggest_force);
+        assert!(!error_occurred);
 
         assert_eq!(cache.symlinks.len(), 1);
         assert_eq!(cache.templates.len(), 0);
@@ -738,8 +738,8 @@ mod test {
             },
         );
 
-        assert_eq!(suggest_force, false);
-        assert_eq!(error_occurred, false);
+        assert!(!suggest_force);
+        assert!(!error_occurred);
 
         assert_eq!(cache.symlinks.len(), 1);
         assert_eq!(cache.templates.len(), 0);
@@ -789,8 +789,8 @@ mod test {
             },
         );
 
-        assert_eq!(suggest_force, false);
-        assert_eq!(error_occurred, false);
+        assert!(!suggest_force);
+        assert!(!error_occurred);
 
         assert_eq!(cache.symlinks.len(), 1);
         assert_eq!(cache.templates.len(), 0);

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -96,6 +96,9 @@ Proceeding by copying instead of symlinking."
                 FileTarget::Symbolic(target) => {
                     desired_symlinks.insert(source, target);
                 }
+                FileTarget::Copy(target) => {
+                    warn!("Copy target not yet implemented");
+                }
                 FileTarget::ComplexTemplate(target) => {
                     desired_templates.insert(source, target);
                 }
@@ -107,6 +110,9 @@ Proceeding by copying instead of symlinking."
                 }
                 FileTarget::Symbolic(target) => {
                     desired_templates.insert(source, target.into_template());
+                }
+                FileTarget::Copy(target) => {
+                    warn!("Copy target not yet implemented");
                 }
                 FileTarget::ComplexTemplate(target) => {
                     desired_templates.insert(source, target);

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -82,42 +82,31 @@ Proceeding by copying instead of symlinking."
     let mut desired_templates = BTreeMap::<PathBuf, TemplateTarget>::new();
 
     for (source, target) in config.files {
-        if symlinks_enabled {
-            match target {
-                FileTarget::Automatic(target) => {
-                    if fs
-                        .is_template(&source)
-                        .context(format!("check whether {:?} is a template", source))?
-                    {
-                        desired_templates.insert(source, target.into());
-                    } else {
-                        desired_symlinks.insert(source, target.into());
-                    }
-                }
-                FileTarget::Symbolic(target) => {
-                    desired_symlinks.insert(source, target);
-                }
-                FileTarget::Copy(target) => {
-                    desired_copies.insert(source, target);
-                }
-                FileTarget::ComplexTemplate(target) => {
-                    desired_templates.insert(source, target);
+        match target {
+            FileTarget::Automatic(target) => {
+                if fs
+                    .is_template(&source)
+                    .context(format!("check whether {:?} is a template", source))?
+                {
+                    desired_templates.insert(source, target.into());
+                } else if symlinks_enabled {
+                    desired_symlinks.insert(source, target.into());
+                } else {
+                    desired_copies.insert(source, target.into());
                 }
             }
-        } else {
-            match target {
-                FileTarget::Automatic(target) => {
-                    desired_templates.insert(source, target.into());
+            FileTarget::Symbolic(target) => {
+                if symlinks_enabled {
+                    desired_symlinks.insert(source, target);
+                } else {
+                    desired_copies.insert(source, target.into());
                 }
-                FileTarget::Symbolic(target) => {
-                    desired_templates.insert(source, target.into_template());
-                }
-                FileTarget::Copy(target) => {
-                    desired_copies.insert(source, target);
-                }
-                FileTarget::ComplexTemplate(target) => {
-                    desired_templates.insert(source, target);
-                }
+            }
+            FileTarget::Copy(target) => {
+                desired_copies.insert(source, target);
+            }
+            FileTarget::ComplexTemplate(target) => {
+                desired_templates.insert(source, target);
             }
         }
     }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -455,8 +455,8 @@ impl Filesystem for RealFilesystem {
         use std::io::Write;
 
         if let Some(owner) = owner {
-            let contents = std::fs::read_to_string(source)
-                .context("read source file contents as current user")?;
+            let contents =
+                std::fs::read(source).context("read source file contents as current user")?;
             let mut child = self
                 .sudo(format!(
                     "Copying {:?} -> {:?} as user {:?}",
@@ -477,7 +477,7 @@ impl Filesystem for RealFilesystem {
                 .stdin
                 .as_ref()
                 .expect("has stdin")
-                .write_all(contents.as_bytes())
+                .write_all(&contents)
                 .context("give input to tee")?;
 
             let success = child.wait().context("wait for sudo tee")?.success();

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -824,7 +824,7 @@ pub enum CopyComparison {
     OnlySourceExists,
     OnlyTargetExists,
     Changed,
-    TargetNotRegularFileOrDirectory,
+    TargetNotRegularFile,
     BothMissing,
 }
 
@@ -836,7 +836,7 @@ impl std::fmt::Display for CopyComparison {
             OnlySourceExists => "target doesn't exist",
             OnlyTargetExists => "source doesn't exist",
             Changed => "target contents were changed",
-            TargetNotRegularFileOrDirectory => "target is not a regular file or directory",
+            TargetNotRegularFile => "target is not a regular file",
             BothMissing => "source and target are missing",
         }
         .fmt(f)
@@ -859,7 +859,7 @@ fn compare_copy(source_state: FileState, target_state: FileState) -> CopyCompari
         (FileState::File(_), FileState::Missing) => CopyComparison::OnlySourceExists,
         (FileState::Missing, FileState::File(_)) => CopyComparison::OnlyTargetExists,
         (FileState::Missing, FileState::Missing) => CopyComparison::BothMissing,
-        _ => CopyComparison::TargetNotRegularFileOrDirectory,
+        _ => CopyComparison::TargetNotRegularFile,
     }
 }
 

--- a/src/handlebars_helpers.rs
+++ b/src/handlebars_helpers.rs
@@ -326,21 +326,11 @@ mod test {
         };
         let handlebars = create_new_handlebars(&mut config).unwrap();
 
-        assert_eq!(
-            eval_condition(&handlebars, &config.variables, "foo").unwrap(),
-            true
-        );
-        assert_eq!(
-            eval_condition(&handlebars, &config.variables, "bar").unwrap(),
-            false
-        );
-        assert_eq!(
-            eval_condition(&handlebars, &config.variables, "dotter.packages.default").unwrap(),
-            true
-        );
-        assert_eq!(
-            eval_condition(&handlebars, &config.variables, "dotter.packages.nonexist").unwrap(),
-            false
+        assert!(eval_condition(&handlebars, &config.variables, "foo").unwrap(),);
+        assert!(!eval_condition(&handlebars, &config.variables, "bar").unwrap(),);
+        assert!(eval_condition(&handlebars, &config.variables, "dotter.packages.default").unwrap(),);
+        assert!(
+            !eval_condition(&handlebars, &config.variables, "dotter.packages.nonexist").unwrap(),
         );
     }
 
@@ -354,18 +344,14 @@ mod test {
         };
         let handlebars = create_new_handlebars(&mut config).unwrap();
 
-        assert_eq!(
-            eval_condition(
-                &handlebars,
-                &config.variables,
-                "(is_executable \"no_such_executable_please\")"
-            )
-            .unwrap(),
-            false
-        );
-        assert_eq!(
+        assert!(!eval_condition(
+            &handlebars,
+            &config.variables,
+            "(is_executable \"no_such_executable_please\")"
+        )
+        .unwrap(),);
+        assert!(
             eval_condition(&handlebars, &config.variables, "(eq (math \"5+5\") \"10\")").unwrap(),
-            true
         );
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -4,6 +4,8 @@ use handlebars::Handlebars;
 use std::path::Path;
 use std::process::Command;
 
+use crate::filesystem::{Filesystem, RealFilesystem};
+
 pub(crate) fn run_hook(
     location: &Path,
     cache_dir: &Path,
@@ -15,23 +17,35 @@ pub(crate) fn run_hook(
         return Ok(());
     }
 
-    let mut script_file = cache_dir.join(location);
-    if cfg!(windows) {
-        script_file.set_extension("bat");
+    let fs: &mut dyn Filesystem = &mut RealFilesystem::new(false);
+
+    // Default to current location
+    let mut script_file = location.into();
+
+    // If it is templated, then render it into cache and run from there
+    if fs
+        .is_template(location)
+        .context(format!("check whether {:?} is a template", location))?
+    {
+        script_file = cache_dir.join(location);
+        if cfg!(windows) {
+            script_file.set_extension("bat");
+        }
+
+        debug!("Rendering script {:?} -> {:?}", location, script_file);
+
+        crate::actions::perform_template_deploy(
+            location,
+            &script_file,
+            &std::env::temp_dir().join("dotter_temp").into(),
+            fs,
+            handlebars,
+            variables,
+        )
+        .context("deploy script")?;
     }
-    debug!("Rendering script {:?} -> {:?}", location, script_file);
 
-    crate::actions::perform_template_deploy(
-        location,
-        &script_file,
-        &std::env::temp_dir().join("dotter_temp").into(),
-        &mut crate::filesystem::RealFilesystem::new(false),
-        handlebars,
-        variables,
-    )
-    .context("deploy script")?;
-
-    debug!("Running script file ");
+    debug!("Running script file");
     let mut child = if cfg!(windows) {
         Command::new(script_file)
             .spawn()

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -17,7 +17,7 @@ pub(crate) fn run_hook(
         return Ok(());
     }
 
-    let fs: &mut dyn Filesystem = &mut RealFilesystem::new(false);
+    let fs = &mut RealFilesystem::new(false);
 
     // Default to current location
     let mut script_file = location.into();

--- a/src/init.rs
+++ b/src/init.rs
@@ -42,6 +42,7 @@ pub fn init(opt: Options) -> Result<()> {
         &opt.cache_file,
         config::Cache {
             symlinks: BTreeMap::default(),
+            copies: BTreeMap::default(),
             templates: BTreeMap::default(),
         },
     )


### PR DESCRIPTION
Closes #77.

Implements a new `copy` target type.

This is a much bigger change than I had expected, so there may be bugs and things I've missed. I've marked the PR as a draft for now, as there are still some things that I think should be discussed:
* It is currently not possible to compare the contents of non-UTF-8 files as all files are read to a string using `std::fs::read_to_string()`. So, non-UTF-8 files end up as `FileState(File(None))`. We could read files into a bytes vector instead using `std::fs::read()`, but this would require changes in a lot of places.
* Currently, if symlinks are not enabled, `symbolic` and `automatic` targets fallback to `template`. I think it would be better to fallback to `copy` instead, though this could potentially be breaking. For `automatic` targets, we can use `fs.is_template()` to determine whether to use `copy` or `template`; whereas for `symbolic`, we would just default to `copy`.
* Hinting to use `copy` in the error for non-UTF-8 templates, as you suggested, would be nice, but I wasn't sure how to fit this in the code.

On a side note, there are a lot of clippy warnings about references. Were those left intentionally?