### PR TITLE
Fix file-not-found errors when handling broken symlinks

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -110,8 +110,7 @@ impl Filesystem for RealFilesystem {
         let link_state = get_file_state(link).context("get link state")?;
         trace!("Link state: {:#?}", link_state);
 
-        let source = real_path(source).context("get real path of source")?;
-        Ok(compare_symlink(&source, source_state, link_state))
+        compare_symlink(source, source_state, link_state)
     }
 
     fn compare_template(&mut self, target: &Path, cache: &Path) -> Result<TemplateComparison> {
@@ -277,8 +276,7 @@ impl Filesystem for RealFilesystem {
         let source_state = get_file_state(source).context("get source state")?;
         let link_state = get_file_state(link).context("get link state")?;
 
-        let source = real_path(source).context("get real path of source")?;
-        Ok(compare_symlink(&source, source_state, link_state))
+        compare_symlink(source, source_state, link_state)
     }
 
     fn compare_template(&mut self, target: &Path, cache: &Path) -> Result<TemplateComparison> {
@@ -589,8 +587,7 @@ impl Filesystem for DryRunFilesystem {
             state
         };
 
-        let source = real_path(source).context("get real path of source")?;
-        Ok(compare_symlink(&source, source_state, link_state))
+        compare_symlink(source, source_state, link_state)
     }
 
     fn compare_template(&mut self, target: &Path, cache: &Path) -> Result<TemplateComparison> {
@@ -760,11 +757,11 @@ fn compare_symlink(
     source_path: &Path,
     source_state: FileState,
     link_state: FileState,
-) -> SymlinkComparison {
-    match (source_state, link_state) {
+) -> Result<SymlinkComparison> {
+    Ok(match (source_state, link_state) {
         (FileState::Missing, FileState::SymbolicLink(_)) => SymlinkComparison::OnlyTargetExists,
         (_, FileState::SymbolicLink(t)) => {
-            if t == source_path {
+            if t == real_path(source_path).context("get real path of source")? {
                 SymlinkComparison::Identical
             } else {
                 SymlinkComparison::Changed
@@ -773,7 +770,7 @@ fn compare_symlink(
         (FileState::Missing, FileState::Missing) => SymlinkComparison::BothMissing,
         (_, FileState::Missing) => SymlinkComparison::OnlySourceExists,
         _ => SymlinkComparison::TargetNotSymlink,
-    }
+    })
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -291,7 +291,7 @@ impl Filesystem for RealFilesystem {
     }
 
     fn remove_file(&mut self, path: &Path) -> Result<()> {
-        let metadata = path.metadata().context("get metadata")?;
+        let metadata = path.symlink_metadata().context("get metadata")?;
         let result = if metadata.is_dir() {
             std::fs::remove_dir_all(path)
         } else {


### PR DESCRIPTION
If a directory `source_dir` exists and contains a file `foo`, and Dotter's config contains `source_dir = "target_dir"`, Dotter will create `target_dir` and link `target_dir/foo` to `source_dir/foo`. If `source_dir/foo` is then deleted, `dotter deploy` will fail:
```
[ERROR] Failed to delete symlink "source_dir/foo" -> "target_dir/foo"
Caused by:
    detect symlink's current state
    get real path of source
    No such file or directory (os error 2)
```

I believe this is the same problem reported by @lumbo7332 in https://github.com/SuperCuber/dotter/issues/55#issuecomment-879532271, and this PR should fix it. It does not address #55 itself, as that seems to be caused by Dotter not handling nonexistent source files gracefully, rather than anything to do with broken symlinks.

As one of my commit messages says, this contains a very minor change to Windows-specific code which I have not tested. This change, however, mirrors the change to the corresponding non-Windows function verbatim (the code could be DRY-er, apparently, but that's an issue for another PR) and so I would be very surprised if it causes any issue.