### PR TITLE
Check if hooks are executable to be self executed

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use handlebars::Handlebars;
 
 use std::path::Path;
-use std::process::Command;
 use std::process::Child;
+use std::process::Command;
 
 pub(crate) fn run_hook(
     location: &Path,
@@ -23,7 +23,7 @@ pub(crate) fn run_hook(
         target.set_extension("bat");
     }
     debug!("Rendering script {:?} -> {:?}", location, script_file);
-    
+
     crate::actions::perform_template_deploy(
         location,
         &script_file,
@@ -51,9 +51,7 @@ fn run_script_file(script: &Path) -> Result<Child> {
 
     let permissions = script.metadata()?.permissions();
     if !script.is_dir() && permissions.mode() & 0o111 != 0 {
-        Command::new(script)
-            .spawn()
-            .context("spawn script file")
+        Command::new(script).spawn().context("spawn script file")
     } else {
         Command::new("sh")
             .arg(script)
@@ -64,7 +62,5 @@ fn run_script_file(script: &Path) -> Result<Child> {
 
 #[cfg(windows)]
 fn run_script_file(script: &Path) -> Result<Child> {
-    Command::new(script)
-            .spawn()
-            .context("spawn batch file")
+    Command::new(script).spawn().context("spawn batch file")
 }


### PR DESCRIPTION
Until now dotter forced script execution through sh and so totally ignoring shebang if exists.
That prevent using other script language than sh like bash, python or whatever

To keep a kind of backward compat, this addition will only run script directly if script file is executable otherwise we fallback on previous way to execute.

Fixes #73

---

Still in draft due to https://github.com/SuperCuber/dotter/issues/73#issuecomment-1004407144