### PR TITLE
Using clap instead of structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,15 +48,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,17 +208,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -392,7 +407,6 @@ dependencies = [
  "serde",
  "shellexpand",
  "simplelog",
- "structopt",
  "tokio",
  "toml 0.4.10",
  "watchexec",
@@ -711,12 +725,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1130,6 +1141,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "parking_lot"
@@ -1639,33 +1656,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1720,12 +1713,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1900,28 +1890,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Unlicense"
 
 [dependencies]
 anyhow = "1.*"
-clap = "2.*"
+clap = { version = "3.*", features = ["derive"] }
 crossterm = "0.18.*"
 diff = "0.1.*"
 handlebars = { version = "4.*", features = ["script_helper"] }
@@ -23,7 +23,6 @@ meval = "0.2.*"
 serde = "1.*"
 shellexpand = "2.*"
 simplelog = "0.12.*"
-structopt = "0.3.*"
 tokio = "1.*"
 toml = "0.4.*"
 watchexec = "=2.0.0-pre.14"

--- a/README.md
+++ b/README.md
@@ -39,54 +39,78 @@ All the files will be deployed to their target locations.
 Check out `dotter -h` for the command-line flags that Dotter supports:
 
 ```
-Dotter 0.12.13
-A small dotfile manager
+dotter 0.12.13
+SuperCuber <amit.gold01@gmail.com>
+A dotfile manager and templater written in rust
 
 USAGE:
-    dotter [FLAGS] [OPTIONS] [SUBCOMMAND]
-
-FLAGS:
-    -d, --dry-run      Dry run - don't do anything, only print information. Implies -v at least once
-    -f, --force        Force - instead of skipping, overwrite target files if their content is unexpected. Overrides
-                       --dry-run
-    -h, --help         Prints help information
-    -y, --noconfirm    Assume "yes" instead of prompting when removing empty directories
-    -p, --patch        Take standard input as an additional files/variables patch, added after evaluating `local.toml`.
-                       Assumes --noconfirm flag because all of stdin is taken as the patch
-    -q, --quiet        Quiet - only print errors
-    -V, --version      Prints version information
-    -v, --verbose      Verbosity level - specify up to 3 times to get more detailed output. Specifying at least once
-                       prints the differences between what was before and after Dotter's run
+    dotter [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
-        --cache-directory <cache-directory>          Directory to cache into [default: .dotter/cache]
-        --cache-file <cache-file>                    Location of cache file [default: .dotter/cache.toml]
-        --diff-context-lines <diff-context-lines>
+        --cache-directory <CACHE_DIRECTORY>
+            Directory to cache into [default: .dotter/cache]
+
+        --cache-file <CACHE_FILE>
+            Location of cache file [default: .dotter/cache.toml]
+
+    -d, --dry-run
+            Dry run - don't do anything, only print information. Implies -v at least once
+
+        --diff-context-lines <DIFF_CONTEXT_LINES>
             Amount of lines that are printed before and after a diff hunk [default: 3]
 
-    -g, --global-config <global-config>              Location of the global configuration [default: .dotter/global.toml]
-    -l, --local-config <local-config>                Location of the local configuration [default: .dotter/local.toml]
-        --post-deploy <post-deploy>
+    -f, --force
+            Force - instead of skipping, overwrite target files if their content is unexpected.
+            Overrides --dry-run
+
+    -g, --global-config <GLOBAL_CONFIG>
+            Location of the global configuration [default: .dotter/global.toml]
+
+    -h, --help
+            Print help information
+
+    -l, --local-config <LOCAL_CONFIG>
+            Location of the local configuration [default: .dotter/local.toml]
+
+    -p, --patch
+            Take standard input as an additional files/variables patch, added after evaluating
+            `local.toml`. Assumes --noconfirm flag because all of stdin is taken as the patch
+
+        --post-deploy <POST_DEPLOY>
             Location of optional post-deploy hook [default: .dotter/post_deploy.sh]
 
-        --post-undeploy <post-undeploy>
+        --post-undeploy <POST_UNDEPLOY>
             Location of optional post-undeploy hook [default: .dotter/post_undeploy.sh]
 
-        --pre-deploy <pre-deploy>
+        --pre-deploy <PRE_DEPLOY>
             Location of optional pre-deploy hook [default: .dotter/pre_deploy.sh]
-        --pre-undeploy <pre-undeploy>
+
+        --pre-undeploy <PRE_UNDEPLOY>
             Location of optional pre-undeploy hook [default: .dotter/pre_undeploy.sh]
 
+    -q, --quiet
+            Quiet - only print errors
+
+    -v, --verbose
+            Verbosity level - specify up to 3 times to get more detailed output. Specifying at least
+            once prints the differences between what was before and after Dotter's run
+
+    -V, --version
+            Print version information
+
+    -y, --noconfirm
+            Assume "yes" instead of prompting when removing empty directories
 
 SUBCOMMANDS:
     deploy      Deploy the files to their respective targets. This is the default subcommand
-    help        Prints this message or the help of the given subcommand(s)
-    init        Initialize global.toml with a single package containing all the files in the current directory
-                pointing to a dummy value and a local.toml that selects that package
-    undeploy    Delete all deployed files from their target locations. Note that this operates on all files that are
-                currently in cache
-    watch       Run continuously, watching the repository for changes and deploying as soon as they happen. Can be
-                ran with `--dry-run`
+    help        Print this message or the help of the given subcommand(s)
+    init        Initialize global.toml with a single package containing all the files in the
+                    current directory pointing to a dummy value and a local.toml that selects that
+                    package
+    undeploy    Delete all deployed files from their target locations. Note that this operates
+                    on all files that are currently in cache
+    watch       Run continuously, watching the repository for changes and deploying as soon as
+                    they happen. Can be ran with `--dry-run`
 ```
 
 # Contributing

--- a/src/args.rs
+++ b/src/args.rs
@@ -7,11 +7,23 @@ use clap::{Parser, Subcommand};
 #[clap(author, version, about, long_about = None)]
 pub struct Options {
     /// Location of the global configuration
-    #[clap(short, long, value_parser, default_value = ".dotter/global.toml", global = true)]
+    #[clap(
+        short,
+        long,
+        value_parser,
+        default_value = ".dotter/global.toml",
+        global = true
+    )]
     pub global_config: PathBuf,
 
     /// Location of the local configuration
-    #[clap(short, long, value_parser, default_value = ".dotter/local.toml", global = true)]
+    #[clap(
+        short,
+        long,
+        value_parser,
+        default_value = ".dotter/local.toml",
+        global = true
+    )]
     pub local_config: PathBuf,
 
     /// Location of cache file

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,80 +1,80 @@
 use std::path::PathBuf;
 
-use structopt::StructOpt;
+use clap::{Parser, Subcommand};
 
-#[derive(Debug, StructOpt, Default, Clone)]
-#[structopt(name = "Dotter")]
 /// A small dotfile manager.
+#[derive(Debug, Parser, Default, Clone)]
+#[clap(author, version, about, long_about = None)]
 pub struct Options {
     /// Location of the global configuration
-    #[structopt(short, long, default_value = ".dotter/global.toml", global = true)]
+    #[clap(short, long, value_parser, default_value = ".dotter/global.toml", global = true)]
     pub global_config: PathBuf,
 
     /// Location of the local configuration
-    #[structopt(short, long, default_value = ".dotter/local.toml", global = true)]
+    #[clap(short, long, value_parser, default_value = ".dotter/local.toml", global = true)]
     pub local_config: PathBuf,
 
     /// Location of cache file
-    #[structopt(long, default_value = ".dotter/cache.toml")]
+    #[clap(long, value_parser, default_value = ".dotter/cache.toml")]
     pub cache_file: PathBuf,
 
     /// Directory to cache into.
-    #[structopt(long, default_value = ".dotter/cache")]
+    #[clap(long, value_parser, default_value = ".dotter/cache")]
     pub cache_directory: PathBuf,
 
     /// Location of optional pre-deploy hook
-    #[structopt(long, default_value = ".dotter/pre_deploy.sh")]
+    #[clap(long, value_parser, default_value = ".dotter/pre_deploy.sh")]
     pub pre_deploy: PathBuf,
 
     /// Location of optional post-deploy hook
-    #[structopt(long, default_value = ".dotter/post_deploy.sh")]
+    #[clap(long, value_parser, default_value = ".dotter/post_deploy.sh")]
     pub post_deploy: PathBuf,
 
     /// Location of optional pre-undeploy hook
-    #[structopt(long, default_value = ".dotter/pre_undeploy.sh")]
+    #[clap(long, value_parser, default_value = ".dotter/pre_undeploy.sh")]
     pub pre_undeploy: PathBuf,
 
     /// Location of optional post-undeploy hook
-    #[structopt(long, default_value = ".dotter/post_undeploy.sh")]
+    #[clap(long, value_parser, default_value = ".dotter/post_undeploy.sh")]
     pub post_undeploy: PathBuf,
 
     /// Dry run - don't do anything, only print information.
     /// Implies -v at least once
-    #[structopt(short = "d", long = "dry-run", parse(from_flag = std::ops::Not::not), global = true)]
+    #[clap(short = 'd', long = "dry-run", parse(from_flag = std::ops::Not::not), global = true)]
     pub act: bool,
 
     /// Verbosity level - specify up to 3 times to get more detailed output.
     /// Specifying at least once prints the differences between what was before and after Dotter's run
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences), global = true)]
-    pub verbosity: u64,
+    #[clap(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
+    pub verbosity: u8,
 
     /// Quiet - only print errors
-    #[structopt(short, long, global = true)]
+    #[clap(short, long, value_parser, global = true)]
     pub quiet: bool,
 
     /// Force - instead of skipping, overwrite target files if their content is unexpected.
     /// Overrides --dry-run.
-    #[structopt(short, long, global = true)]
+    #[clap(short, long, value_parser, global = true)]
     pub force: bool,
 
     /// Assume "yes" instead of prompting when removing empty directories
-    #[structopt(short = "y", long = "noconfirm", parse(from_flag = std::ops::Not::not), global = true)]
+    #[clap(short = 'y', long = "noconfirm", parse(from_flag = std::ops::Not::not), global = true)]
     pub interactive: bool,
 
     /// Take standard input as an additional files/variables patch, added after evaluating
     /// `local.toml`. Assumes --noconfirm flag because all of stdin is taken as the patch.
-    #[structopt(short, long, global = true)]
+    #[clap(short, long, value_parser, global = true)]
     pub patch: bool,
 
     /// Amount of lines that are printed before and after a diff hunk.
-    #[structopt(long, default_value = "3")]
+    #[clap(long, value_parser, default_value = "3")]
     pub diff_context_lines: usize,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub action: Option<Action>,
 }
 
-#[derive(Debug, Clone, Copy, StructOpt)]
+#[derive(Debug, Clone, Copy, Subcommand)]
 pub enum Action {
     /// Deploy the files to their respective targets. This is the default subcommand.
     Deploy,
@@ -99,7 +99,7 @@ impl Default for Action {
 }
 
 pub fn get_options() -> Options {
-    let mut opt = Options::from_args();
+    let mut opt = Options::parse();
     if !opt.act {
         opt.verbosity = std::cmp::max(opt.verbosity, 1);
     }


### PR DESCRIPTION
Most of the features of structopt are now in clap v3. 