### PR TITLE
Adding generation of shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4179da71abd56c26b54dd0c248cc081c1f43b0a1a7e8448e28e57a29baa993d"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +402,7 @@ version = "0.12.13"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossterm",
  "diff",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Unlicense"
 [dependencies]
 anyhow = "1.*"
 clap = { version = "3.*", features = ["derive"] }
+clap_complete = "3.*"
 crossterm = "0.18.*"
 diff = "0.1.*"
 handlebars = { version = "4.*", features = ["script_helper"] }

--- a/README.md
+++ b/README.md
@@ -102,16 +102,17 @@ OPTIONS:
             Assume "yes" instead of prompting when removing empty directories
 
 SUBCOMMANDS:
-    deploy      Deploy the files to their respective targets. This is the default subcommand
+    deploy             Deploy the files to their respective targets. This is the default
+                           subcommand
     gen-completions    Generate shell completions
-    help        Print this message or the help of the given subcommand(s)
-    init        Initialize global.toml with a single package containing all the files in the
-                    current directory pointing to a dummy value and a local.toml that selects that
-                    package
-    undeploy    Delete all deployed files from their target locations. Note that this operates
-                    on all files that are currently in cache
-    watch       Run continuously, watching the repository for changes and deploying as soon as
-                    they happen. Can be ran with `--dry-run`
+    help               Print this message or the help of the given subcommand(s)
+    init               Initialize global.toml with a single package containing all the files in
+                           the current directory pointing to a dummy value and a local.toml that
+                           selects that package
+    undeploy           Delete all deployed files from their target locations. Note that this
+                           operates on all files that are currently in cache
+    watch              Run continuously, watching the repository for changes and deploying as
+                           soon as they happen. Can be ran with `--dry-run`
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     deploy      Deploy the files to their respective targets. This is the default subcommand
+    gen-completions    Generate shell completions
     help        Print this message or the help of the given subcommand(s)
     init        Initialize global.toml with a single package containing all the files in the
                     current directory pointing to a dummy value and a local.toml that selects that

--- a/src/args.rs
+++ b/src/args.rs
@@ -109,7 +109,7 @@ pub enum Action {
         /// Set the shell for generating completions [values: bash, elvish, fish, powerShell, zsh]
         #[clap(long, short)]
         shell: Shell,
-    }
+    },
 }
 
 impl Default for Action {

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 
 /// A small dotfile manager.
 #[derive(Debug, Parser, Default, Clone)]
@@ -102,6 +103,13 @@ pub enum Action {
     /// Run continuously, watching the repository for changes and deploying as soon as they
     /// happen. Can be ran with `--dry-run`
     Watch,
+
+    /// Generate shell completions
+    GenCompletions {
+        /// Set the shell for generating completions [values: bash, elvish, fish, powerShell, zsh]
+        #[clap(long, short)]
+        shell: Shell,
+    }
 }
 
 impl Default for Action {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,11 @@ mod hooks;
 mod init;
 mod watch;
 
+use std::io;
+
 use anyhow::{Context, Result};
+use clap::CommandFactory;
+use clap_complete::generate;
 
 fn main() {
     match run() {
@@ -103,6 +107,9 @@ Otherwise, run `dotter undeploy` as root, remove cache.toml and cache/ folders, 
                 .expect("create a tokio runtime")
                 .block_on(watch::watch(opt))
                 .context("watch repository")?;
+        }
+        args::Action::GenCompletions { shell } => {
+            generate(shell, &mut args::Options::command(), "dotter", &mut io::stdout());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,12 @@ Otherwise, run `dotter undeploy` as root, remove cache.toml and cache/ folders, 
                 .context("watch repository")?;
         }
         args::Action::GenCompletions { shell } => {
-            generate(shell, &mut args::Options::command(), "dotter", &mut io::stdout());
+            generate(
+                shell,
+                &mut args::Options::command(),
+                "dotter",
+                &mut io::stdout(),
+            );
         }
     }
 


### PR DESCRIPTION
There is an issue for that (https://github.com/SuperCuber/dotter/issues/65), it prints to stdout the completion.

It is intended to be use like: 
 `dotter gen-completions --shell "zsh" >> ./file.txt`