### PR TITLE
Fix inverted flags

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -54,7 +54,7 @@ pub struct Options {
     /// Dry run - don't do anything, only print information.
     /// Implies -v at least once
     #[clap(short = 'd', long = "dry-run", global = true)]
-    pub act: bool,
+    pub dry_run: bool,
 
     /// Verbosity level - specify up to 3 times to get more detailed output.
     /// Specifying at least once prints the differences between what was before and after Dotter's run
@@ -120,7 +120,7 @@ impl Default for Action {
 
 pub fn get_options() -> Options {
     let mut opt = Options::parse();
-    if !opt.act {
+    if opt.dry_run {
         opt.verbosity = std::cmp::max(opt.verbosity, 1);
     }
     opt.verbosity = std::cmp::min(3, opt.verbosity);

--- a/src/args.rs
+++ b/src/args.rs
@@ -72,7 +72,7 @@ pub struct Options {
 
     /// Assume "yes" instead of prompting when removing empty directories
     #[clap(short = 'y', long = "noconfirm", global = true)]
-    pub interactive: bool,
+    pub noconfirm: bool,
 
     /// Take standard input as an additional files/variables patch, added after evaluating
     /// `local.toml`. Assumes --noconfirm flag because all of stdin is taken as the patch.
@@ -125,7 +125,7 @@ pub fn get_options() -> Options {
     }
     opt.verbosity = std::cmp::min(3, opt.verbosity);
     if opt.patch {
-        opt.interactive = false;
+        opt.noconfirm = true;
     }
     opt
 }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -42,7 +42,7 @@ pub fn deploy(opt: &Options) -> Result<bool> {
     let handlebars = create_new_handlebars(&mut config).context("initialize handlebars")?;
 
     debug!("Running pre-deploy hook");
-    if opt.act {
+    if !opt.dry_run {
         hooks::run_hook(
             &opt.pre_deploy,
             &opt.cache_directory,
@@ -53,7 +53,7 @@ pub fn deploy(opt: &Options) -> Result<bool> {
     }
 
     let (mut real_fs, mut dry_run_fs);
-    let fs: &mut dyn Filesystem = if opt.act {
+    let fs: &mut dyn Filesystem = if !opt.dry_run {
         real_fs = crate::filesystem::RealFilesystem::new(opt.interactive);
         &mut real_fs
     } else {
@@ -139,12 +139,12 @@ Proceeding by copying instead of symlinking."
         error_occurred = true;
     }
 
-    if opt.act {
+    if !opt.dry_run {
         filesystem::save_file(&opt.cache_file, cache).context("save cache")?;
     }
 
     debug!("Running post-deploy hook");
-    if opt.act {
+    if !opt.dry_run {
         hooks::run_hook(
             &opt.post_deploy,
             &opt.cache_directory,
@@ -170,7 +170,7 @@ pub fn undeploy(opt: Options) -> Result<bool> {
     // === Pre-undeploy ===
 
     debug!("Running pre-undeploy hook");
-    if opt.act {
+    if !opt.dry_run {
         hooks::run_hook(
             &opt.pre_undeploy,
             &opt.cache_directory,
@@ -184,7 +184,7 @@ pub fn undeploy(opt: Options) -> Result<bool> {
     let mut error_occurred = false;
 
     let (mut real_fs, mut dry_run_fs);
-    let fs: &mut dyn Filesystem = if opt.act {
+    let fs: &mut dyn Filesystem = if !opt.dry_run {
         real_fs = crate::filesystem::RealFilesystem::new(opt.interactive);
         &mut real_fs
     } else {
@@ -227,14 +227,14 @@ pub fn undeploy(opt: Options) -> Result<bool> {
         error_occurred = true;
     }
 
-    if opt.act {
+    if !opt.dry_run {
         // Should be empty if everything went well, but if some things were skipped this contains
         // them.
         filesystem::save_file(&opt.cache_file, cache).context("save cache")?;
     }
 
     debug!("Running post-undeploy hook");
-    if opt.act {
+    if !opt.dry_run {
         hooks::run_hook(
             &opt.post_undeploy,
             &opt.cache_directory,

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -54,7 +54,7 @@ pub fn deploy(opt: &Options) -> Result<bool> {
 
     let (mut real_fs, mut dry_run_fs);
     let fs: &mut dyn Filesystem = if !opt.dry_run {
-        real_fs = crate::filesystem::RealFilesystem::new(opt.interactive);
+        real_fs = crate::filesystem::RealFilesystem::new(opt.noconfirm);
         &mut real_fs
     } else {
         dry_run_fs = crate::filesystem::DryRunFilesystem::new();
@@ -185,7 +185,7 @@ pub fn undeploy(opt: Options) -> Result<bool> {
 
     let (mut real_fs, mut dry_run_fs);
     let fs: &mut dyn Filesystem = if !opt.dry_run {
-        real_fs = crate::filesystem::RealFilesystem::new(opt.interactive);
+        real_fs = crate::filesystem::RealFilesystem::new(opt.noconfirm);
         &mut real_fs
     } else {
         dry_run_fs = crate::filesystem::DryRunFilesystem::new();

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -89,13 +89,13 @@ pub trait Filesystem {
 
 #[cfg(windows)]
 pub struct RealFilesystem {
-    interactive: bool,
+    noconfirm: bool,
 }
 
 #[cfg(windows)]
 impl RealFilesystem {
-    pub fn new(interactive: bool) -> RealFilesystem {
-        RealFilesystem { interactive }
+    pub fn new(noconfirm: bool) -> RealFilesystem {
+        RealFilesystem { noconfirm }
     }
 }
 
@@ -145,7 +145,7 @@ impl Filesystem for RealFilesystem {
                 .next()
                 .is_none()
         {
-            if (!self.interactive || no_ask)
+            if (self.noconfirm || no_ask)
                 || ask_boolean(&format!(
                     "Directory at {:?} is now empty. Delete [y/N]? ",
                     path
@@ -231,16 +231,16 @@ impl Filesystem for RealFilesystem {
 
 #[cfg(unix)]
 pub struct RealFilesystem {
-    interactive: bool,
+    noconfirm: bool,
     sudo_occurred: bool,
 }
 
 #[cfg(unix)]
 impl RealFilesystem {
-    pub fn new(interactive: bool) -> RealFilesystem {
+    pub fn new(noconfirm: bool) -> RealFilesystem {
         RealFilesystem {
             sudo_occurred: false,
-            interactive,
+            noconfirm,
         }
     }
 
@@ -326,7 +326,7 @@ impl Filesystem for RealFilesystem {
                 .next()
                 .is_none()
         {
-            if (!self.interactive || no_ask)
+            if (self.noconfirm || no_ask)
                 || ask_boolean(&format!(
                     "Directory at {:?} is now empty. Delete [y/N]? ",
                     path


### PR DESCRIPTION
I introduced a bug in #108, the flags `dry-run` and `interactive` were true by default.