### PR TITLE
Add config command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +430,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
 
 [[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "git+https://github.com/SIMULATAN/dialoguer#4d222a6ed1d7cf54e939e57c2c268e3b1d7eda3e"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +491,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "dialoguer",
  "diff",
  "dunce",
  "evalexpr",
@@ -503,6 +529,12 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "endian-type"
@@ -1748,6 +1780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shellexpand"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,3 +2565,9 @@ dependencies = [
  "quote",
  "syn 2.0.49",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,12 +395,12 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+source = "git+https://github.com/SIMULATAN/dialoguer#f2efb751cffda840ec07787029f7f0a33767f30d"
 dependencies = [
  "console",
  "shell-words",
  "tempfile",
+ "thiserror",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +393,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +454,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "dialoguer",
  "diff",
  "dunce",
  "handlebars",
@@ -466,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "enquote"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +544,7 @@ checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
 ]
 
@@ -1160,7 +1201,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1354,13 +1395,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -1498,6 +1548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shellexpand"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1671,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1835,6 +1905,12 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "utf8parse"
@@ -2075,3 +2151,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.4"
-source = "git+https://github.com/SIMULATAN/dialoguer#786e19d39746c8fd49816a655d7cea225e569d9b"
+source = "git+https://github.com/SIMULATAN/dialoguer#4d222a6ed1d7cf54e939e57c2c268e3b1d7eda3e"
 dependencies = [
  "console",
  "shell-words",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.4"
-source = "git+https://github.com/SIMULATAN/dialoguer#f2efb751cffda840ec07787029f7f0a33767f30d"
+source = "git+https://github.com/SIMULATAN/dialoguer#786e19d39746c8fd49816a655d7cea225e569d9b"
 dependencies = [
  "console",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ shellexpand = "2.*"
 simplelog = "0.12.*"
 tokio = "1.*"
 toml = "0.4.*"
-dialoguer = { version = "0.10.2", features = [] }
+dialoguer = { git = "https://github.com/SIMULATAN/dialoguer", features = [] }
 watchexec = {version="=2.0.0-pre.14", optional = true}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ shellexpand = "2.*"
 simplelog = "0.12.*"
 tokio = "1.*"
 toml = "0.4.*"
+dialoguer = { version = "0.10.2", features = ["completion"] }
 watchexec = {version="=2.0.0-pre.14", optional = true}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.*"
 clap = { version = "4.0.26", features = ["derive"] }
 clap_complete = "4.0.5"
 crossterm = "0.25.0"
+dialoguer = { git = "https://github.com/SIMULATAN/dialoguer", features = [] }
 diff = "0.1.*"
 handlebars = "5.*"
 hostname = "0.3.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ shellexpand = "2.*"
 simplelog = "0.12.*"
 tokio = "1.*"
 toml = "0.4.*"
-dialoguer = { version = "0.10.2", features = ["completion"] }
+dialoguer = { version = "0.10.2", features = [] }
 watchexec = {version="=2.0.0-pre.14", optional = true}
 
 [features]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Usage: dotter [OPTIONS] [COMMAND]
 
 Commands:
   deploy           Deploy the files to their respective targets. This is the default subcommand
+  config           Interactively modify the local configuration file
   undeploy         Delete all deployed files from their target locations. Note that this operates on all files that are currently in cache
   init             Initialize global.toml with a single package containing all the files in the current directory pointing to a dummy value and a local.toml that selects that package
   watch            Run continuously, watching the repository for changes and deploying as soon as they happen. Can be ran with `--dry-run`

--- a/src/args.rs
+++ b/src/args.rs
@@ -93,6 +93,9 @@ pub enum Action {
     #[default]
     Deploy,
 
+    /// Modify the local configuration file.
+    Config,
+
     /// Delete all deployed files from their target locations.
     /// Note that this operates on all files that are currently in cache.
     Undeploy,

--- a/src/args.rs
+++ b/src/args.rs
@@ -93,7 +93,7 @@ pub enum Action {
     #[default]
     Deploy,
 
-    /// Modify the local configuration file.
+    /// Interactively modify the local configuration file.
     Config,
 
     /// Delete all deployed files from their target locations.

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ use crate::filesystem;
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -93,7 +92,7 @@ pub struct Configuration {
     pub recurse: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Package {
     #[serde(default)]
@@ -104,7 +103,7 @@ pub struct Package {
     variables: Variables,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GlobalConfig {
     #[serde(default)]
     #[cfg(feature = "scripting")]
@@ -115,7 +114,7 @@ pub struct GlobalConfig {
 
 type IncludedConfig = BTreeMap<String, Package>;
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LocalConfig {
     #[serde(default)]
@@ -125,17 +124,6 @@ pub struct LocalConfig {
     files: Files,
     #[serde(default)]
     variables: Variables,
-}
-
-impl LocalConfig {
-    pub fn empty_config() -> Self {
-        Self {
-            includes: Vec::new(),
-            packages: Vec::new(),
-            files: Files::new(),
-            variables: Variables::new(),
-        }
-    }
 }
 
 pub fn load_configuration(
@@ -659,19 +647,5 @@ mod tests {
             .is_err(),
             true
         );
-    }
-}
-
-impl Eq for Package {}
-
-impl PartialEq for Package {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self, other)
-    }
-}
-
-impl Hash for Package {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        std::ptr::hash(self, state);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,7 @@ pub struct Configuration {
 #[serde(deny_unknown_fields)]
 pub struct Package {
     #[serde(default)]
-    depends: Vec<String>,
+    pub depends: Vec<String>,
     #[serde(default)]
     files: Files,
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use crate::filesystem;
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -658,5 +659,19 @@ mod tests {
             .is_err(),
             true
         );
+    }
+}
+
+impl Eq for Package {}
+
+impl PartialEq for Package {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self, other)
+    }
+}
+
+impl Hash for Package {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::ptr::hash(self, state);
     }
 }

--- a/src/local_config.rs
+++ b/src/local_config.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use dialoguer::MultiSelect;
 use crate::args::Options;
 use crate::filesystem;
-use crate::config::{Configuration, GlobalConfig, load_global_config, load_local_config, LocalConfig, merge_configuration_files, Package};
+use crate::config::{GlobalConfig, load_global_config, load_local_config, LocalConfig, Package};
 
 /// Returns true if an error was printed
 pub fn config(opt: &Options) -> Result<bool> {
@@ -17,9 +17,7 @@ pub fn config(opt: &Options) -> Result<bool> {
 
         let mut local_config: LocalConfig = load_local_config(&opt.local_config)?;
 
-        // this "config" variable will only contain the ENABLED packages
-        let config: Configuration = merge_configuration_files(global_config.clone(), local_config.clone(), None)?;
-        let enabled_packages = config.packages;
+        let enabled_packages = &local_config.packages;
 
         // all packages, including the ones that are disabled
         let packages: Vec<PackageNames> = get_packages(global_config.packages);
@@ -33,7 +31,7 @@ pub fn config(opt: &Options) -> Result<bool> {
 
         match selected_items {
             Some(selected_items) => {
-                modify_and_save(opt, &mut local_config, packages.iter().map(|(key, _)| key).collect(), selected_items)?;
+                modify_and_save(opt, &mut local_config, packages.iter().map(|(_, value)| value).collect(), selected_items)?;
             }
             None => {
                 // user pressed "Esc" or "q" to quit

--- a/src/local_config.rs
+++ b/src/local_config.rs
@@ -1,0 +1,78 @@
+use anyhow::Context;
+use anyhow::Result;
+use dialoguer::MultiSelect;
+use crate::args::Options;
+use crate::filesystem;
+use crate::config::{Configuration, GlobalConfig, load_global_config, load_local_config, LocalConfig, merge_configuration_files};
+
+/// Returns true if an error was printed
+pub fn config(opt: &Options) -> Result<bool> {
+    let global_config: GlobalConfig = load_global_config(&opt.global_config)?;
+
+    let mut multi_select = MultiSelect::new();
+
+    return if opt.local_config.exists() {
+        debug!("Local configuration file found at {}", opt.local_config.display());
+
+        let mut local_config: LocalConfig = load_local_config(&opt.local_config)?;
+
+        // this "config" variable will only contain the ENABLED packages
+        let config: Configuration = merge_configuration_files(global_config.clone(), local_config.clone(), None)?;
+        let enabled_packages = config.packages;
+
+        // all packages, including the ones that are disabled
+        let packages: Vec<&String> = global_config.packages.keys().collect();
+        for name in &packages {
+            multi_select.item_checked(name, enabled_packages.contains_key(*name));
+        }
+
+        println!("Use space to select packages to enable, and enter to confirm");
+        let selected_items = multi_select.interact_opt()?;
+        trace!("Selected elements: {:?}", selected_items);
+
+        match selected_items {
+            Some(selected_items) => {
+                modify_and_save(opt, &mut local_config, packages, selected_items)?;
+            }
+            None => {
+                // user pressed "Esc" or "q" to quit
+                println!("Aborting.");
+            }
+        }
+        Ok(false)
+    } else {
+        debug!("No local configuration file found at {}", opt.local_config.display());
+        let packages: Vec<&String> = global_config.packages.keys().collect();
+        trace!("Available packages: {:?}", packages);
+
+        println!("Use space to select packages to enable, and enter to confirm");
+        let selected_elements = multi_select.with_prompt("Select packages to install")
+            .items(&packages)
+            .interact_opt()?;
+        trace!("Selected elements: {:?}", selected_elements);
+
+        match selected_elements {
+            Some(selected_elements) if selected_elements.is_empty() => {
+                println!("No packages selected, writing empty configuration");
+                filesystem::save_file(opt.local_config.as_path(), LocalConfig::empty_config())
+                    .context("Writing empty configuration")?;
+            }
+            Some(selected_elements) => {
+                modify_and_save(opt, &mut LocalConfig::empty_config(), packages, selected_elements)?;
+            },
+            None => {
+                // user pressed "Esc" or "q" to quit
+                println!("Aborting.");
+            }
+        }
+        Ok(false)
+    }
+}
+
+fn modify_and_save(opt: &Options, local_config: &mut LocalConfig, items_in_order: Vec<&String>, selected_items: Vec<usize>) -> Result<()> {
+    println!("Writing configuration to {}", opt.local_config.display());
+    trace!("Selected indexes: {:?} of {:?}", selected_items, items_in_order);
+    local_config.packages = selected_items.iter().map(|i| items_in_order[*i].clone()).collect();
+    filesystem::save_file(&opt.local_config, local_config)
+        .context("Writing local config to file")
+}

--- a/src/local_config.rs
+++ b/src/local_config.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use anyhow::{Context, Error};
+use crossterm::style::{style, Color, Stylize};
 use dialoguer::{MultiSelectPlus, MultiSelectPlusItem};
 
 use crate::args::Options;
@@ -102,7 +103,11 @@ fn write_selected_elements(
 
 fn format_package(package_name: &String, dependencies: &Vec<String>) -> String {
     let dependencies_string = if !dependencies.is_empty() {
-        format!(" # (will enable {})", dependencies.join(", "))
+        style(format!(" # (will enable {})", dependencies.join(", ")))
+            // fallback for terms not supporting 8-bit ANSI
+            .with(Color::White)
+            .with(Color::AnsiValue(244))
+            .to_string()
     } else {
         String::new()
     };

--- a/src/local_config.rs
+++ b/src/local_config.rs
@@ -115,16 +115,12 @@ fn prompt(
                     MultiSelectPlusItem {
                         name: format_package(key, value),
                         status: if enabled_packages.contains(key) {
-                            MultiSelectPlusStatus::CHECKED
-                        } else if is_transitive_dependency(key, packages, enabled_packages) {
-                            let status = MultiSelectPlusStatus {
-                                checked: false,
-                                symbol: "-",
-                            };
-                            status
-                        } else {
-                            MultiSelectPlusStatus::UNCHECKED
-                        },
+                                MultiSelectPlusStatus::CHECKED
+                            } else if is_transitive_dependency(key, packages, enabled_packages) {
+                                DEPENDENCY
+                            } else {
+                                MultiSelectPlusStatus::UNCHECKED
+                            },
                         summary_text: key.clone(),
                     }
                 })
@@ -187,7 +183,7 @@ fn format_package(package_name: &String, dependencies: &Vec<String>) -> String {
     format!("{package_name}{dependencies_string}")
 }
 
-/// (package_name, dependencies)
+/// (package_name, dependencies) - includes transitive dependencies
 type PackageNames = (String, Vec<String>);
 
 fn get_package_dependencies<'a>(
@@ -247,5 +243,6 @@ fn modify_and_save(
         .map(|i| items_in_order[*i].clone())
         .collect::<Vec<String>>();
 
-    filesystem::save_file(config_path, local_config).context("Writing local config to file")
+    filesystem::save_file(config_path, local_config)
+        .context("Writing local config to file")
 }

--- a/src/local_config.rs
+++ b/src/local_config.rs
@@ -24,7 +24,7 @@ pub fn config(opt: &Options) -> Result<bool> {
 
     let mut multi_select = MultiSelect::new();
 
-    return if opt.local_config.exists() {
+    if opt.local_config.exists() {
         debug!(
             "Local configuration file found at {}",
             opt.local_config.display()
@@ -60,7 +60,6 @@ pub fn config(opt: &Options) -> Result<bool> {
                 println!("Aborting.");
             }
         }
-        Ok(false)
     } else {
         debug!(
             "No local configuration file found at {}",
@@ -104,8 +103,9 @@ pub fn config(opt: &Options) -> Result<bool> {
                 println!("Aborting.");
             }
         }
-        Ok(false)
     };
+
+    Ok(false)
 }
 
 fn format_package(package_name: &String, dependencies: &Vec<String>) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod filesystem;
 mod handlebars_helpers;
 mod hooks;
 mod init;
+mod local_config;
 #[cfg(feature = "watch")]
 mod watch;
 
@@ -94,6 +95,13 @@ Otherwise, run `dotter undeploy` as root, remove cache.toml and cache/ folders, 
         args::Action::Deploy => {
             debug!("Deploying...");
             if deploy::deploy(&opt).context("deploy")? {
+                // An error occurred
+                return Ok(false);
+            }
+        }
+        args::Action::Config => {
+            debug!("Configuring...");
+            if local_config::config(&opt).context("config")? {
                 // An error occurred
                 return Ok(false);
             }


### PR DESCRIPTION
This command can be used to configure the packages in the `local.toml` file. This is particularly useful when bootstrapping new devices where you quickly want to select what packages to install.

I also plan on creating a more feature rich TUI for the local config including changing variables, but I wanted to get some feedback first before making deeper changes.

Please review this change and tell me what to improve as some things I changed probably should be done in another way (most notably, making a few of the `config` structs + fields public).

### Notes
- This introduces a new dependency, [dialoguer](https://crates.io/crates/dialoguer), which adds around 100 KB to the release binary (which is 16 MB at the moment)
- I had to make a few of the structs in `config.rs` public to access them in the new file (`config_local.rs`). I wasn't sure if I should add the command to the existing `config.rs` file as that one was already quite long even before my changes

I'd be happy to hear feedback and improve this pr based on it. Thanks for your work on this project!