### PR TITLE
feat: create ci/cd for macos-x86_64/aarch64

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-aarch64]
         include:
           - os: ubuntu-latest
             exe_suffix: ""
@@ -17,6 +17,12 @@ jobs:
           - os: windows-latest
             exe_suffix: ".exe"
             target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            exe_suffix: ""
+            target: x86_64-apple-darwin
+          - os: macos-aarch64
+            exe_suffix: ""
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v3
       - name: Update rust
@@ -31,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           asset_path: target/${{ matrix.target }}/release/dotter${{ matrix.exe_suffix }}
-          asset_name: dotter${{ matrix.exe_suffix }}
+          asset_name: dotter-${{matrix.target}}${{ matrix.exe_suffix }}
           asset_content_type: application/octet-stream
           upload_url: ${{ github.event.release.upload_url }}
   build-completions:

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-aarch64]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             exe_suffix: ""

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest
             exe_suffix: ""
             target: x86_64-apple-darwin
-          - os: macos-aarch64
+          - os: macos-latest
             exe_suffix: ""
             target: aarch64-apple-darwin
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest, macos-aarch64]
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -19,6 +19,8 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: macos-latest
             target: x86_64-apple-darwin
+          - os: macos-aarch64
+            target: aarch64-apple-darwin
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest, macos-aarch64]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: macos-latest
             target: x86_64-apple-darwin
-          - os: macos-aarch64
+          - os: macos-latest
             target: aarch64-apple-darwin
       fail-fast: false
     steps:


### PR DESCRIPTION
Hi @SuperCuber  !
I've made a few changes to the project that I'd like to bring to your attention. The main thrust of these changes is adding support for macOS platform in GitHub Actions.

I want to add dotter to brew and this PR is needed to install binary files from the repository

