### PR TITLE
allow disabling scripting and watch command using feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ shellexpand = "2.*"
 simplelog = "0.12.*"
 tokio = "1.*"
 toml = "0.4.*"
-watchexec = "=2.0.0-pre.14"
+watchexec = {version="=2.0.0-pre.14", optional = true}
 
 [features]
-default = ["scripting"]
+default = ["scripting", "watch"]
 scripting = ["handlebars/script_helper"]
-
+watch = ["watchexec"]
 
 [dependencies.handlebars_misc_helpers]
 version = "0.12.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,22 @@ clap = { version = "4.0.26", features = ["derive"] }
 clap_complete = "4.0.5"
 crossterm = "0.25.0"
 diff = "0.1.*"
-handlebars = { version = "4.*", features = ["script_helper"] }
+handlebars = "4.*"
 hostname = "0.3.*"
 log = "0.4.*"
 maplit = "1.*"
 meval = "0.2.*"
-serde = "1.*"
+serde = {version = "1.*", features = ["derive"]}
 shellexpand = "2.*"
 simplelog = "0.12.*"
 tokio = "1.*"
 toml = "0.4.*"
 watchexec = "=2.0.0-pre.14"
+
+[features]
+default = ["scripting"]
+scripting = ["handlebars/script_helper"]
+
 
 [dependencies.handlebars_misc_helpers]
 version = "0.12.*"

--- a/src/args.rs
+++ b/src/args.rs
@@ -103,6 +103,7 @@ pub enum Action {
 
     /// Run continuously, watching the repository for changes and deploying as soon as they
     /// happen. Can be ran with `--dry-run`
+    #[cfg(feature = "watch")]
     Watch,
 
     /// Generate shell completions

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,14 +63,17 @@ enum FileTargetInnerRepr {
 
 pub type Files = BTreeMap<PathBuf, FileTarget>;
 pub type Variables = toml::value::Table;
+#[cfg(feature = "scripting")]
 pub type Helpers = BTreeMap<String, PathBuf>;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {
     pub files: Files,
     pub variables: Variables,
-    pub helpers: Helpers,
     pub packages: Vec<String>,
+    
+    #[cfg(feature = "scripting")]
+    pub helpers: Helpers,
 
     /// If the source is a directory, or a symlink to a directory,
     /// and this option is true, the source will be recursed and
@@ -93,6 +96,7 @@ pub struct Package {
 #[derive(Debug, Deserialize, Serialize)]
 struct GlobalConfig {
     #[serde(default)]
+    #[cfg(feature = "scripting")]
     helpers: Helpers,
     #[serde(flatten)]
     packages: BTreeMap<String, Package>,
@@ -165,6 +169,7 @@ pub fn load_configuration(
 
     trace!("Final files: {:#?}", merged_config.files);
     trace!("Final variables: {:#?}", merged_config.variables);
+    #[cfg(feature = "scripting")]
     trace!("Final helpers: {:?}", merged_config.helpers);
 
     Ok(merged_config)
@@ -193,6 +198,7 @@ pub fn save_dummy_config(
     let mut packages = BTreeMap::new();
     packages.insert("default".into(), package);
     let global_config = GlobalConfig {
+        #[cfg(feature = "scripting")]
         helpers: Helpers::new(),
         packages,
     };
@@ -302,6 +308,7 @@ fn merge_configuration_files(
     global.packages.retain(|k, _| enabled_packages.contains(k));
 
     let mut output = Configuration {
+        #[cfg(feature = "scripting")]
         helpers: global.helpers,
         files: Files::default(),
         variables: Variables::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod filesystem;
 mod handlebars_helpers;
 mod hooks;
 mod init;
+#[cfg(feature = "watch")]
 mod watch;
 
 use std::fmt::Write;
@@ -102,6 +103,7 @@ Otherwise, run `dotter undeploy` as root, remove cache.toml and cache/ folders, 
             debug!("Initializing repo...");
             init::init(opt).context("initalize directory")?;
         }
+        #[cfg(feature = "watch")]
         args::Action::Watch => {
             debug!("Watching...");
             tokio::runtime::Runtime::new()


### PR DESCRIPTION
# Why?
These features are relatively easy to just not use. 
- Running dotter every 3 minutes by hand isn't that hard
- templating is already **very** useful without the whole rhai scripting thing

Yet these two features make up roughly half of compile time and dependency graph(117/236). 

The watch command also currently breaks dotter on FreeBSD since the watchexec version in use depends on an outdated version of notify-rs. Bumping watchexec is not trivial due to more broken dependencies.

# Solution?
The watch command and handlebars scripting are now behind their own feature flags(`watch` and `scripting` respectively). These are in the default feature set, so no change for the average user.
If you want to turn them off you can now do so using the usual `cargo --no-default-features` ways.
