### PR TITLE
Add handlebars helper to print environment variables

### DIFF
--- a/src/handlebars_helpers.rs
+++ b/src/handlebars_helpers.rs
@@ -219,6 +219,28 @@ fn command_output_helper(
     Ok(())
 }
 
+fn env_helper(
+    h: &Helper<'_, '_>,
+    _: &Handlebars<'_>,
+    _: &Context,
+    _: &mut RenderContext<'_, '_>,
+    out: &mut dyn Output,
+) -> HelperResult {
+    let mut params = h.params().iter();
+    let variable = params
+        .next()
+        .ok_or_else(|| RenderError::new("env: No variable name given"))?
+        .render();
+    if params.next().is_some() {
+        return Err(RenderError::new("env: More than one parameter given"));
+    }
+
+    let value = std::env::var(variable).unwrap_or_default();
+    out.write(&value)?;
+
+    Ok(())
+}
+
 #[cfg(windows)]
 fn is_executable(name: &str) -> Result<bool, std::io::Error> {
     let name = if name.ends_with(".exe") {
@@ -269,6 +291,7 @@ fn register_rust_helpers(handlebars: &mut Handlebars<'_>) {
     handlebars.register_helper("is_executable", Box::new(is_executable_helper));
     handlebars.register_helper("command_success", Box::new(command_success_helper));
     handlebars.register_helper("command_output", Box::new(command_output_helper));
+    handlebars.register_helper("env", Box::new(env_helper));
 }
 
 #[cfg(feature = "scripting")]


### PR DESCRIPTION
# Problem

Sometimes, for example when referencing a file in a config, a relative path is enough, so no issues in this case. And some configs are scripts (for example zsh configs), so I can access the env-vars also easily  at runtime. But some configs require absolute paths, and also aren't scripts. So if I need to reference a file in the /home directory of the user, I need the path at render-time. My current workaround is `{{ command_output "echo -n ${HOME}" }}`, that works, but isn't nice. So just being able to access the env-vars directly at render-time with `{{ env "HOME" }}` makes this a lot easier. :)

# Solution

So this is mostly for me to have access to `$HOME` and `$USER` env vars, but since it's maybe also useful for other env-vars in the future, I directly created a dynamic helper to give access to all env-vars, instead of just adding static variables for `home` and `user`.