### PR TITLE
Allow passing variables defined by `assign` to `include_template`.

### DIFF
--- a/src/handlebars_helpers.rs
+++ b/src/handlebars_helpers.rs
@@ -103,7 +103,7 @@ fn include_template_helper(
     h: &Helper<'_, '_>,
     handlebars: &Handlebars<'_>,
     ctx: &Context,
-    _: &mut RenderContext<'_, '_>,
+    rc: &mut RenderContext<'_, '_>,
     out: &mut dyn Output,
 ) -> HelperResult {
     let mut params = h.params().iter();
@@ -120,7 +120,7 @@ fn include_template_helper(
     let included_file = std::fs::read_to_string(path)
         .map_err(|e| RenderError::from_error("include_template", e))?;
     let rendered_file = handlebars
-        .render_template_with_context(&included_file, ctx)
+        .render_template_with_context(&included_file, rc.context().as_deref().unwrap_or(ctx))
         .map_err(|e| RenderError::from_error("include_template", e))?;
 
     out.write(&rendered_file)?;


### PR DESCRIPTION
This change allows using the `assign` helper from `handlebars_misc_helpers` to pass variables into templates rendered with `include_template`. The `assign` helper modifies the `RenderContext` and previously `include_template` would use the `Context` when rendering the template. The change attempts to use the `RenderContext` with a fallback to use the `Context` if no `RenderContext` exists.

Note that this change does not address `handlebars_misc_helpers` #65. The `assign` helper clones the `Context` and overwrites the `RenderContext` on every call meaning that only variables defined by the most recent `assign` call will be available.

Resolves #134.

@SuperCuber, thanks for your time so far. I've put this PR together assuming no changes are made in `handlebars_misc_helpers`. I didn't add any tests because external test template files would be needed and wasn't sure how you would want those organized. Let me know if you want me to revisit this. I'm also not sure how long you want to wait on feedback on https://github.com/davidB/handlebars_misc_helpers/issues/65.