### PR TITLE
Optmize binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ hostname = "0.3.*"
 log = "0.4.*"
 maplit = "1.*"
 meval = "0.2.*"
-serde = {version = "1.*", features = ["derive"]}
+serde = { version = "1.*", features = ["derive"] }
 shellexpand = "2.*"
 simplelog = "0.12.*"
 tokio = "1.*"
 toml = "0.4.*"
-watchexec = {version="=2.0.0-pre.14", optional = true}
+watchexec = { version = "=2.0.0-pre.14", optional = true }
 
 [features]
 default = ["scripting", "watch"]
@@ -48,3 +48,10 @@ dunce = "1.*"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.137"
+
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
This PR aims to reduce the size of the compiled `dotter` binary. I'm taking your advice and including the final binary in my dotfiles but I thought the final binary size was a bit larger than I'd like. I followed the steps [here](https://github.com/johnthagen/min-sized-rust) and reduced the file size from 17M to 4.9M.

This PR adds 5 new flags to the release profile in Cargo.toml:

- `strip = true`: strip symbols
- `opt-level = "z"`: optimize for file size instead of execution speed (more below)
- `lto = true`: enable Link Time Optimization
- `codegen-units = 1`: reduces parallel codegen units from 16 to 1
- `panic = "abort"`: prevents unwinding the stack on a panic and prevents displaying a stacktrace

The `strip` and `lto` optimizations have no downsizes but the others have some potential negative effects.

## Impact on File Size

| strip | opt-level | lto | codegen-units | panic | binary size |
| ----- | --------- | --- | ------------- | ----- | ----------- |
|       |           |     |               |       | 17M         |
| X     |           |     |               |       | 9.8M        |
| X     | X         |     |               |       | 8.2M        |
| X     | X         | X   |               |       | 6.0M        |
| X     | X         | X   | X             |       | 5.5M        |
| X     | X         | X   | X             | X     | 4.9M        |

## Impact on Execution Time

`opt-level` can potentially increase execution time. However, I benchmarked `cargo test --release` using `hyperfine` and found that there were almost no difference in test time.

```bash
hyperfine "cargo test --release"
```

| strip | opt-level | lto | execution time     |
| ----- | --------- | --- | ------------------ |
|       |           |     | 165.1 ms ± 11.2 ms |
| X     |           |     | 164.4 ms ± 19.0 ms |
| X     | X         |     | 163.7 ms ± 5.6 ms  |
| X     | X         | X   | 170.3 ms ± 24.5 ms |

## Impact on Build Time

`codegen-units = 1` can slow down build times. In my testing, I was building from a clean repo for each run so build times are pretty long. But I think build times will be impacted much less when using cached builds.

```bash
hyperfine --prepare "cargo clean" --runs 3 "cargo build --release"
```

| strip | opt-level | lto | codegen-units | panic | build time         |
| ----- | --------- | --- | ------------- | ----- | ------------------ |
|       |           |     |               |       | 50.777 s ± 0.149 s |
| X     |           |     |               |       | 50.399 s ± 0.195 s |
| X     | X         |     |               |       | 40.503 s ± 0.017 s |
| X     | X         | X   |               |       | 65.934 s ± 0.019 s |
| X     | X         | X   | X             |       | 68.089 s ± 0.554 s |
| X     | X         | X   | X             | X     | 61.976 s ± 0.434 s |

I'm not sure if there's any interest for this kind of PR but I thought I'd throw it out there. Thanks for you review.
