### PR TITLE
Indicate required Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["dotter", "dotfiles", "manager"]
 categories = ["command-line-utilities"]
 license = "Unlicense"
+rust-version = "1.70"
 
 [dependencies]
 anyhow = "1.*"


### PR DESCRIPTION
This improves the error message when using an older compiler. I got a "use of unstable feature is_ok_and" error because I was still on 1.68.