### PR TITLE
Upgrade handlebars to version 5.1 to support chained else expression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +382,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "cruet"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6132609543972496bc97b1e01f1ce6586768870aeb4cabeb3385f4e05b5caead"
+dependencies = [
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.5.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
+checksum = "c73166c591e67fb4bf9bc04011b4e35f12e89fe8d676193aa263df065955a379"
 dependencies = [
  "log",
  "pest",
@@ -972,11 +972,11 @@ dependencies = [
 
 [[package]]
 name = "handlebars_misc_helpers"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3e2b811ca7bc497bc12f8ab4b6315c21323b9a187989965edf7dd54f841837"
+checksum = "3d23af2de02b372be35cf2c6a99a8481064dd9e5fc39c625a82b45da9ea22838"
 dependencies = [
- "Inflector",
+ "cruet",
  "enquote",
  "handlebars",
  "jmespath",
@@ -986,7 +986,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "toml 0.7.8",
+ "toml 0.8.8",
 ]
 
 [[package]]
@@ -2019,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "indexmap",
  "serde",
@@ -2041,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 clap_complete = "4.0.5"
 crossterm = "0.25.0"
 diff = "0.1.*"
-handlebars = "4.*"
+handlebars = "5.*"
 hostname = "0.3.*"
 log = "0.4.*"
 maplit = "1.*"
@@ -37,7 +37,7 @@ scripting = ["handlebars/script_helper"]
 watch = ["watchexec", "watchexec-events", "watchexec-filterer-tagged"]
 
 [dependencies.handlebars_misc_helpers]
-version = "0.13.*"
+version = "0.15.*"
 default-features = false
 features = ["string", "json"]
 

--- a/src/handlebars_helpers.rs
+++ b/src/handlebars_helpers.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context as AnyhowContext, Result};
 
-use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContext, RenderError};
+use handlebars::{
+    Context, Handlebars, Helper, HelperResult, Output, RenderContext, RenderErrorReason,
+};
 use toml::value::{Table, Value};
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -65,7 +67,7 @@ fn eval_condition(handlebars: &Handlebars, variables: &Variables, condition: &st
 }
 
 fn math_helper(
-    h: &Helper<'_, '_>,
+    h: &Helper<'_>,
     _: &Handlebars<'_>,
     _: &Context,
     _: &mut RenderContext<'_, '_>,
@@ -81,7 +83,7 @@ fn math_helper(
     out.write(
         &evalexpr::eval(&expression)
             .map_err(|e| {
-                RenderError::new(format!(
+                RenderErrorReason::Other(format!(
                     "Cannot evaluate expression {} because {}",
                     expression, e
                 ))
@@ -92,7 +94,7 @@ fn math_helper(
 }
 
 fn include_template_helper(
-    h: &Helper<'_, '_>,
+    h: &Helper<'_>,
     handlebars: &Handlebars<'_>,
     ctx: &Context,
     rc: &mut RenderContext<'_, '_>,
@@ -101,19 +103,23 @@ fn include_template_helper(
     let mut params = h.params().iter();
     let path = params
         .next()
-        .ok_or_else(|| RenderError::new("include_template: No path given"))?
+        .ok_or(RenderErrorReason::ParamNotFoundForIndex(
+            "include_template",
+            0,
+        ))?
         .render();
     if params.next().is_some() {
-        return Err(RenderError::new(
-            "include_template: More than one parameter given",
-        ));
+        return Err(RenderErrorReason::Other(
+            "include_template: More than one parameter given".to_owned(),
+        )
+        .into());
     }
 
-    let included_file = std::fs::read_to_string(path)
-        .map_err(|e| RenderError::from_error("include_template", e))?;
+    let included_file =
+        std::fs::read_to_string(path).map_err(|e| RenderErrorReason::NestedError(Box::new(e)))?;
     let rendered_file = handlebars
         .render_template_with_context(&included_file, rc.context().as_deref().unwrap_or(ctx))
-        .map_err(|e| RenderError::from_error("include_template", e))?;
+        .map_err(|e| RenderErrorReason::NestedError(Box::new(e)))?;
 
     out.write(&rendered_file)?;
 
@@ -121,7 +127,7 @@ fn include_template_helper(
 }
 
 fn is_executable_helper(
-    h: &Helper<'_, '_>,
+    h: &Helper<'_>,
     _: &Handlebars<'_>,
     _: &Context,
     _: &mut RenderContext<'_, '_>,
@@ -130,16 +136,17 @@ fn is_executable_helper(
     let mut params = h.params().iter();
     let executable = params
         .next()
-        .ok_or_else(|| RenderError::new("is_executable: No executable name given"))?
+        .ok_or(RenderErrorReason::ParamNotFoundForIndex("is_executable", 0))?
         .render();
     if params.next().is_some() {
-        return Err(RenderError::new(
-            "is_executable: More than one parameter given",
-        ));
+        return Err(RenderErrorReason::Other(
+            "is_executable: More than one parameter given".to_owned(),
+        )
+        .into());
     }
 
     let status =
-        is_executable(&executable).map_err(|e| RenderError::from_error("is_executable", e))?;
+        is_executable(&executable).map_err(|e| RenderErrorReason::NestedError(Box::new(e)))?;
     if status {
         out.write("true")?;
     }
@@ -149,7 +156,7 @@ fn is_executable_helper(
 }
 
 fn command_success_helper(
-    h: &Helper<'_, '_>,
+    h: &Helper<'_>,
     _: &Handlebars<'_>,
     _: &Context,
     _: &mut RenderContext<'_, '_>,
@@ -158,12 +165,16 @@ fn command_success_helper(
     let mut params = h.params().iter();
     let command = params
         .next()
-        .ok_or_else(|| RenderError::new("command_success: No executable name given"))?
+        .ok_or(RenderErrorReason::ParamNotFoundForIndex(
+            "command_success",
+            0,
+        ))?
         .render();
     if params.next().is_some() {
-        return Err(RenderError::new(
-            "command_success: More than one parameter given",
-        ));
+        return Err(RenderErrorReason::Other(
+            "command_success: More than one parameter given".to_owned(),
+        )
+        .into());
     }
 
     let status = os_shell()
@@ -182,7 +193,7 @@ fn command_success_helper(
 }
 
 fn command_output_helper(
-    h: &Helper<'_, '_>,
+    h: &Helper<'_>,
     _: &Handlebars<'_>,
     _: &Context,
     _: &mut RenderContext<'_, '_>,
@@ -191,12 +202,16 @@ fn command_output_helper(
     let mut params = h.params().iter();
     let command = params
         .next()
-        .ok_or_else(|| RenderError::new("command_success: No executable name given"))?
+        .ok_or(RenderErrorReason::ParamNotFoundForIndex(
+            "command_success",
+            0,
+        ))?
         .render();
     if params.next().is_some() {
-        return Err(RenderError::new(
-            "command_success: More than one parameter given",
-        ));
+        return Err(RenderErrorReason::Other(
+            "command_success: More than one parameter given".to_owned(),
+        )
+        .into());
     }
 
     let output = os_shell()


### PR DESCRIPTION
The new version now supports a syntax like this:
```handlebars
{{#if ...}}
{{else if ...}}
{{else}}
{{/if}}
```

Also update `handlebars_misc_helpers` to be compatible with the new `handlebars` version.

Also refactor `RenderError`s to `RenderErrorReason`s to fix deprecation warnings.