### PR TITLE
Append new/unknown packages from included files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -282,10 +282,8 @@ fn merge_configuration_files(
             }
 
             if !included.is_empty() {
-                anyhow::bail!(
-                    "unknown packages: {:?}",
-                    included.keys().cloned().collect::<Vec<_>>()
-                );
+                debug!("append unknown packages: {:?}", included.keys());
+                global.packages.append(&mut included);
             }
 
             Ok(())


### PR DESCRIPTION
I have some configs for work, which I didn't want to add to my main repo, and I created a separate repo for it, which I then included in the `local.toml` only on my work PC. This works fine as long as I only want to add additional files to existing packages. But when I wanted to add a config for a package which isn't in my main `global.toml`, it failed. I needed to create an empty package in the `global.toml` to which I then can add the files from my included repo.

With this change, I can include packages from my `local.toml` where the main `global.toml` doesn't need to know anything about it.

I don't know if I'm overlooking something here, and if there was a reason why unknown packages were rejected before (and even made it hard fail and not just print a warning). But in my local testing this small change works perfectly fine for my use-case. I'm just a bit confused as this case was already explicitly handled before (so it was known it can happen and wasn't just overlooked), so please tell me if I'm missing something.