### PR TITLE
adding global variable to enable symlinks by default if type not specified

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -697,20 +697,13 @@ mod test {
         )
         .unwrap();
 
-        let merged_config =
-            merge_configuration_files(global, local, None);
+        let merged_config = merge_configuration_files(global, local, None);
 
         let config = merged_config.unwrap();
 
-        let cat = config
-            .files
-            .get(&PathBuf::from("cat"))
-            .unwrap();
+        let cat = config.files.get(&PathBuf::from("cat")).unwrap();
 
-        let derby = config
-            .files
-            .get(&PathBuf::from("derby"))
-            .unwrap();
+        let derby = config.files.get(&PathBuf::from("derby")).unwrap();
 
         assert_eq!(
             cat,
@@ -757,20 +750,13 @@ mod test {
         )
         .unwrap();
 
-        let merged_config =
-            merge_configuration_files(global, local, None);
+        let merged_config = merge_configuration_files(global, local, None);
 
         let config = merged_config.unwrap();
 
-        let cat = config
-            .files
-            .get(&PathBuf::from("cat"))
-            .unwrap();
+        let cat = config.files.get(&PathBuf::from("cat")).unwrap();
 
-        let derby = config
-            .files
-            .get(&PathBuf::from("derby"))
-            .unwrap();
+        let derby = config.files.get(&PathBuf::from("derby")).unwrap();
 
         assert_eq!(
             cat,
@@ -820,25 +806,15 @@ mod test {
         )
         .unwrap();
 
-        let merged_config =
-            merge_configuration_files(global, local, None);
+        let merged_config = merge_configuration_files(global, local, None);
 
         let config = merged_config.unwrap();
 
-        let cat = config
-            .files
-            .get(&PathBuf::from("cat"))
-            .unwrap();
+        let cat = config.files.get(&PathBuf::from("cat")).unwrap();
 
-        let derby = config
-            .files
-            .get(&PathBuf::from("derby"))
-            .unwrap();
+        let derby = config.files.get(&PathBuf::from("derby")).unwrap();
 
-        let sliver = config
-            .files
-            .get(&PathBuf::from("sliver"))
-            .unwrap();
+        let sliver = config.files.get(&PathBuf::from("sliver")).unwrap();
 
         assert_eq!(
             cat,

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,7 @@ pub struct Configuration {
     /// are readable.
     pub recurse: bool,
 
+    #[allow(dead_code)]
     pub settings: Settings,
 }
 

--- a/src/handlebars_helpers.rs
+++ b/src/handlebars_helpers.rs
@@ -351,6 +351,8 @@ fn add_dotter_variable(
 
 #[cfg(test)]
 mod test {
+    use crate::config::Settings;
+
     use super::*;
 
     #[test]
@@ -362,6 +364,7 @@ mod test {
             helpers: Helpers::new(),
             packages: maplit::btreemap! { "default".into() => true, "disabled".into() => false },
             recurse: true,
+            settings: Settings::default(),
         };
         let handlebars = create_new_handlebars(&mut config).unwrap();
 
@@ -388,6 +391,7 @@ mod test {
             helpers: Helpers::new(),
             packages: BTreeMap::new(),
             recurse: true,
+            settings: Settings::default(),
         };
         let handlebars = create_new_handlebars(&mut config).unwrap();
 


### PR DESCRIPTION
howdy, I am interested in this feature as well, https://github.com/SuperCuber/dotter/issues/169, and took a shot at implementing it. I am not very practiced in rust lately so I just wanted to make sure I could at least get something that worked before getting caught up in any specifics like where to store the config or what to name it.

This PR adds a variables field to the GlobalConfig. Then, when merging and processing the config files, it checks for a field, `enable_symlink_by_default`, and if that is true, it converts any packages with any files that are FileTarget::Automatic to FileTarget::Symbolic. I thought the deployer shouldn't really care about the FileTarget type and decided to handle this conversion in the config. I also added a test to show it converts FileTarget::Automatic package files but not a specified template.

Please let me know your thoughts and feedback, thanks.