### PR TITLE
Move recurse flag to Settings struct

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -824,7 +824,7 @@ mod test {
 
         assert_eq!(
             cat,
-            &FileTarget::Automatic(PathBuf::from("~/.QuarticCat").into())
+            &FileTarget::Automatic(PathBuf::from("~/.QuarticCat"))
         );
 
         assert_eq!(

--- a/src/handlebars_helpers.rs
+++ b/src/handlebars_helpers.rs
@@ -363,7 +363,6 @@ mod test {
             #[cfg(feature = "scripting")]
             helpers: Helpers::new(),
             packages: maplit::btreemap! { "default".into() => true, "disabled".into() => false },
-            recurse: true,
             settings: Settings::default(),
         };
         let handlebars = create_new_handlebars(&mut config).unwrap();
@@ -390,7 +389,6 @@ mod test {
             #[cfg(feature = "scripting")]
             helpers: Helpers::new(),
             packages: BTreeMap::new(),
-            recurse: true,
             settings: Settings::default(),
         };
         let handlebars = create_new_handlebars(&mut config).unwrap();


### PR DESCRIPTION
After this change, the flag will be available in global.toml in
```toml
[settings]
recurse = false
[package.files]
whatever...
```

- [ ] Fix bug with removing directory symbolic link on windows (permission denied)
- [ ]  Add documentation to the wiki about global and per-file option