### PR TITLE
fix: exclude cache and .git from watch filter (fixes #196)

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -15,16 +15,16 @@ pub(crate) async fn watch(opt: Options) -> Result<()> {
 
     let filter = GlobsetFilterer::new(
         std::env::current_dir()?,
+        vec![],
         vec![
-            (format!("!{}/", opt.cache_directory.display()), None),
-            (format!("!{}", opt.cache_file.display()), None),
-            ("!.git/".to_string(), None),
-            ("!DOTTER_SYMLINK_TEST".to_string(), None),
+            (format!("{}/", opt.cache_directory.display()), None),
+            (format!("{}", opt.cache_file.display()), None),
+            (".git/".to_string(), None),
+            ("DOTTER_SYMLINK_TEST".to_string(), None),
         ],
         vec![],
         vec![],
         vec![],
-        vec![], // Add the 6th argument (extensions)
     )
     .await?;
 


### PR DESCRIPTION
`dotter watch` redeploys in an infinite loop because the glob filter is inert.

Fixes #196 

They found out about this issue long before, and theorised it's something to do with dependencies? idk

Worth considering to merge at least, i believe idk.

Likely root cause: 
`src/watch.rs` passes `!`-prefixed globs as `GlobsetFilterer::new`'s filters argument (2nd) while leaving ignores (3rd) empty. 
Now since the `!` prefix is `.gitignore` negation syntax,  the patterns register as whitelists — `filters.num_ignores()` returns 0, the filter block in `watchexec-filterer-globset` is skipped entirely, and nothing is ever excluded. Cache writes from deploy retrigger the watcher.


Fix: Move the globs to ignores and drop the !. I think they were always meant to be exclusions??


Tested on macOS (#196 was on  Windows, so issue is not OS-specific). Verified with deploy target and log file both safely outside the watched tree:
 • 0 deploys on no change
 • Exactly 1 deploy per source edit