### PR TITLE
Nit: Have automatic template detection warn in the same way as symlink detection

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -834,7 +834,7 @@ pub fn is_template(source: &Path) -> Result<bool> {
         Ok(false)
     } else if buf.contains("{{") {
         warn!(
-            "File {:?} contains \"{{\" - detecting as template. Explicitly specify it to silence this message.",
+            "File {:?} contains \"{{{{\" - detecting as template. Explicitly specify it to silence this message.",
             source
         );
         Ok(true)

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -832,8 +832,14 @@ pub fn is_template(source: &Path) -> Result<bool> {
             source
         );
         Ok(false)
+    } else if buf.contains("{{") {
+        warn!(
+            "File {:?} contains \"{{\" - detecting as template. Explicitly specify it to silence this message.",
+            source
+        );
+        Ok(true)
     } else {
-        Ok(buf.contains("{{"))
+        Ok(false)
     }
 }
 


### PR DESCRIPTION
I mean, for symlinks it works, but for the whole thing that carries to that functions *name* it doesn't warn the user to better explicitly specify wether this is a template or not.