### PR TITLE
Create dotter.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "diff",
+ "dirs",
  "dunce",
  "evalexpr",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ toml = "1"
 watchexec = { version = "8", optional = true }
 watchexec-events = { version = "6.0.0", optional = true }
 watchexec-filterer-globset = { version = "8", optional = true }
+dirs = "4.0.0"
 
 [features]
 default = ["scripting", "watch"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, CommandFactory, FromArgMatches};
 use clap_complete::Shell;
 
 /// A small dotfile manager.
@@ -118,8 +118,62 @@ pub enum Action {
     },
 }
 
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+#[serde(default)]
+pub struct DotterSettings {
+    pub repo: Option<PathBuf>,
+    pub force: Option<bool>,
+    pub noconfirm: Option<bool>,
+    pub quiet: Option<bool>,
+    pub diff_context_lines: Option<usize>,
+    pub verbosity: Option<u8>,
+}
+
+fn load_settings_file(path: &std::path::Path) -> Option<DotterSettings> {
+    if let Ok(content) = std::fs::read_to_string(path) {
+        toml::from_str(&content).ok()
+    } else {
+        None
+    }
+}
+
 pub fn get_options() -> Options {
-    let mut opt = Options::parse();
+    let matches = Options::command().get_matches();
+    let mut opt = Options::from_arg_matches(&matches).unwrap();
+
+    let global_settings = dirs::config_dir()
+        .map(|d| d.join("dotter").join("dotter.toml"))
+        .and_then(|p: std::path::PathBuf| load_settings_file(&p))
+        .unwrap_or_default();
+
+    if let Some(repo) = &global_settings.repo {
+        if let Err(e) = std::env::set_current_dir(repo) {
+            log::warn!("Failed to cd to repo {:?}: {}", repo, e);
+        }
+    }
+
+    let repo_settings = load_settings_file(std::path::Path::new("dotter.toml")).unwrap_or_default();
+
+    let from_cli = |id: &str| {
+        matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine)
+    };
+
+    if !from_cli("force") {
+        opt.force = repo_settings.force.or(global_settings.force).unwrap_or(opt.force);
+    }
+    if !from_cli("noconfirm") {
+        opt.noconfirm = repo_settings.noconfirm.or(global_settings.noconfirm).unwrap_or(opt.noconfirm);
+    }
+    if !from_cli("quiet") {
+        opt.quiet = repo_settings.quiet.or(global_settings.quiet).unwrap_or(opt.quiet);
+    }
+    if !from_cli("diff_context_lines") {
+        opt.diff_context_lines = repo_settings.diff_context_lines.or(global_settings.diff_context_lines).unwrap_or(opt.diff_context_lines);
+    }
+    if !from_cli("verbosity") {
+        opt.verbosity = repo_settings.verbosity.or(global_settings.verbosity).unwrap_or(opt.verbosity);
+    }
+
     if opt.dry_run {
         opt.verbosity = std::cmp::max(opt.verbosity, 1);
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -145,7 +145,7 @@ fn load_settings_file(path: &std::path::Path) -> Option<DotterSettings> {
 
 pub fn get_options() -> Options {
     let matches = Options::command().get_matches();
-    let mut opt = Options::from_arg_matches(&matches).unwrap();
+    let mut opt = Options::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
 
     //TODO: do you agree, mr. maintainer SuperCuber, with the decision of having the config file
     //come from whatever `dirs` considers the platform-specific dirs? namely: https://docs.rs/dirs/latest/dirs/fn.config_dir.html

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,6 +3,12 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand, CommandFactory, FromArgMatches};
 use clap_complete::Shell;
 
+type ForceType = bool;
+type NoConfirmType = bool;
+type QuietType= bool;
+type DiffContextLinesType= usize;
+type VerbosityType = u8;
+
 /// A small dotfile manager.
 #[derive(Debug, Parser, Default, Clone)]
 #[clap(author, version, about, long_about = None)]
@@ -59,20 +65,20 @@ pub struct Options {
     /// Verbosity level - specify up to 3 times to get more detailed output.
     /// Specifying at least once prints the differences between what was before and after Dotter's run
     #[clap(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
-    pub verbosity: u8,
+    pub verbosity: VerbosityType,
 
     /// Quiet - only print errors
     #[clap(short, long, value_parser, global = true)]
-    pub quiet: bool,
+    pub quiet: QuietType,
 
     /// Force - instead of skipping, overwrite target files if their content is unexpected.
     /// Overrides --dry-run.
     #[clap(short, long, value_parser, global = true)]
-    pub force: bool,
+    pub force: ForceType,
 
     /// Assume "yes" instead of prompting when removing empty directories
     #[clap(short = 'y', long = "noconfirm", global = true)]
-    pub noconfirm: bool,
+    pub noconfirm: NoConfirmType,
 
     /// Take standard input as an additional files/variables patch, added after evaluating
     /// `local.toml`. Assumes --noconfirm flag because all of stdin is taken as the patch.
@@ -81,7 +87,7 @@ pub struct Options {
 
     /// Amount of lines that are printed before and after a diff hunk.
     #[clap(long, value_parser, default_value = "3")]
-    pub diff_context_lines: usize,
+    pub diff_context_lines: DiffContextLinesType,
 
     #[clap(subcommand)]
     pub action: Option<Action>,
@@ -122,11 +128,11 @@ pub enum Action {
 #[serde(default)]
 pub struct DotterSettings {
     pub repo: Option<PathBuf>,
-    pub force: Option<bool>,
-    pub noconfirm: Option<bool>,
-    pub quiet: Option<bool>,
-    pub diff_context_lines: Option<usize>,
-    pub verbosity: Option<u8>,
+    pub force: Option<ForceType>,
+    pub noconfirm: Option<NoConfirmType>,
+    pub quiet: Option<QuietType>,
+    pub diff_context_lines: Option<DiffContextLinesType>,
+    pub verbosity: Option<VerbosityType>,
 }
 
 fn load_settings_file(path: &std::path::Path) -> Option<DotterSettings> {

--- a/src/args.rs
+++ b/src/args.rs
@@ -147,7 +147,12 @@ pub fn get_options() -> Options {
     let matches = Options::command().get_matches();
     let mut opt = Options::from_arg_matches(&matches).unwrap();
 
+    //TODO: do you agree, mr. maintainer SuperCuber, with the decision of having the config file
+    //come from whatever `dirs` considers the platform-specific dirs? namely: https://docs.rs/dirs/latest/dirs/fn.config_dir.html
+    //or should we make it all be just ~/.config/dotter/dotter.toml?
+    //first of all, i like that path for MacOS as well, and it also works for Windows, technically. `~/` resolved everywhere.
     let global_settings = dirs::config_dir()
+        // dotter/dotter.toml
         .map(|d| d.join("dotter").join("dotter.toml"))
         .and_then(|p: std::path::PathBuf| load_settings_file(&p))
         .unwrap_or_default();

--- a/src/args.rs
+++ b/src/args.rs
@@ -163,7 +163,8 @@ pub fn get_options() -> Options {
         }
     }
 
-    let repo_settings = load_settings_file(std::path::Path::new("dotter.toml")).unwrap_or_default();
+    let repo_settings = load_settings_file(std::path::Path::new("dotter.toml")).unwrap_or_default(); //not
+    //sure what the default here would be tho
 
     let from_cli = |id: &str| {
         matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine)

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,4 @@
+use crate::filesystem;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, CommandFactory, FromArgMatches};
@@ -136,11 +137,10 @@ pub struct DotterSettings {
 }
 
 fn load_settings_file(path: &std::path::Path) -> Option<DotterSettings> {
-    if let Ok(content) = std::fs::read_to_string(path) {
-        toml::from_str(&content).ok()
-    } else {
+    filesystem::load_file(path).unwrap_or_else(|e| {
+        log::warn!("Failed to load settings file {:?}: {:#}", path, e);
         None
-    }
+    })
 }
 
 pub fn get_options() -> Options {

--- a/src/args.rs
+++ b/src/args.rs
@@ -69,21 +69,21 @@ pub struct Options {
     pub verbosity: VerbosityType,
 
     /// Quiet - only print errors
-    #[clap(short, long, value_parser, global = true)]
+    #[clap(short, long, action = clap::ArgAction::SetTrue, global = true)]
     pub quiet: QuietType,
 
     /// Force - instead of skipping, overwrite target files if their content is unexpected.
     /// Overrides --dry-run.
-    #[clap(short, long, value_parser, global = true)]
+    #[clap(short, long, action = clap::ArgAction::SetTrue, global = true)]
     pub force: ForceType,
 
     /// Assume "yes" instead of prompting when removing empty directories
-    #[clap(short = 'y', long = "noconfirm", global = true)]
+    #[clap(short = 'y', long = "noconfirm", action = clap::ArgAction::SetTrue, global = true)]
     pub noconfirm: NoConfirmType,
 
     /// Take standard input as an additional files/variables patch, added after evaluating
     /// `local.toml`. Assumes --noconfirm flag because all of stdin is taken as the patch.
-    #[clap(short, long, value_parser, global = true)]
+    #[clap(short, long, global = true)]
     pub patch: bool,
 
     /// Amount of lines that are printed before and after a diff hunk.


### PR DESCRIPTION
I got your comment from 2021, dude 

> Maybe it's about time we had a dotter.toml for these kinds of settings...

https://github.com/SuperCuber/dotter/issues/51#issuecomment-770217516

And yeah, I made it be read from a global config, and also introduced a couple of (i thought) relevant settings that take precedence in the order 
compiled defaults < `~/.config/dotter/dotter.toml` (for linux) < `<repo>/dotter.toml` < CLI flags

If you could come up with relevant settings as well.

And if you could, also please think if it's better to have `~/.config/dotter/dotter.toml` in general, or keep them sepparete per-OS in the way the `dirs` crate defines them?: https://docs.rs/dirs/latest/dirs/fn.config_dir.html

Also, this doesn't introduce new depedencies, dirs was already there.

Alsoo, i made these ones as well as stacked PR's to deduplicate the uglyness of merging configs , pick your liking
This (which i preffer / reccomend) 
#223 
First time i've written a macro lol, we're all learning

Also this one if we don't like macros:
#224

Feel free to close which one you prefer

Update: uhh idk how to declare them as  stacked PRs

<img width="644" height="356" alt="image" src="https://github.com/user-attachments/assets/b42f255a-1b8f-4580-826f-429bea7c1970" />
